### PR TITLE
Add FontContext to handle KH2 fonts easily

### DIFF
--- a/OpenKh.Kh2/Bar.cs
+++ b/OpenKh.Kh2/Bar.cs
@@ -28,6 +28,7 @@ namespace OpenKh.Kh2
             Imgz = 29,
 			Seb = 31,
 			Wd = 32,
+            RawBitmap = 36,
             Vibration = 47,
 			Vag = 48,
 		}

--- a/OpenKh.Kh2/Contextes/FontContext.cs
+++ b/OpenKh.Kh2/Contextes/FontContext.cs
@@ -28,10 +28,10 @@ namespace OpenKh.Kh2.Contextes
                 switch (entry.Name)
                 {
                     case "sys":
-                        Read(entry, ref imageSystem, ref spacingSystem, 512, 256, false);
+                        Read(entry, ref imageSystem, ref spacingSystem, false);
                         break;
                     case "evt":
-                        Read(entry, ref imageEvent, ref spacingEvent, 512, 512, false);
+                        Read(entry, ref imageEvent, ref spacingEvent, false);
                         break;
                     case "icon":
                         Read(entry, ref imageIcon, ref spacingIcon, 256, 160, true);
@@ -40,17 +40,73 @@ namespace OpenKh.Kh2.Contextes
             }
         }
 
+        private void Read(Bar.Entry entry, ref IImageRead image, ref byte[] spacing, bool is8bit)
+        {
+            switch (entry.Type)
+            {
+                case Bar.EntryType.Msg:
+                    spacing = ReadSpacing(entry);
+                    break;
+                case Bar.EntryType.RawBitmap:
+                    image = ReadImage(entry, is8bit);
+                    break;
+            }
+        }
+
         private void Read(Bar.Entry entry, ref IImageRead image, ref byte[] spacing, int width, int height, bool is8bit)
         {
             switch (entry.Type)
             {
                 case Bar.EntryType.Msg:
-                    spacing = new BinaryReader(entry.Stream).ReadBytes((int)entry.Stream.Length);
+                    spacing = ReadSpacing(entry);
                     break;
                 case Bar.EntryType.RawBitmap:
-                    image = RawBitmap.Read(entry.Stream, width, height, is8bit);
+                    image = ReadImage(entry, width, height, is8bit);
                     break;
             }
+        }
+
+        private static byte[] ReadSpacing(Bar.Entry entry)
+        {
+            return new BinaryReader(entry.Stream).ReadBytes((int)entry.Stream.Length);
+        }
+
+        private static IImageRead ReadImage(Bar.Entry entry, bool is8bit)
+        {
+            DeductImageSize((int)entry.Stream.Length, out var width, out var height);
+            return ReadImage(entry, width, height, is8bit);
+        }
+
+        private static IImageRead ReadImage(Bar.Entry entry, int width, int height, bool is8bit)
+        {
+            return RawBitmap.Read(entry.Stream, width, height, is8bit);
+        }
+
+        private static bool DeductImageSize(int rawLength, out int width, out int height)
+        {
+            if (rawLength < 128 * 1024)
+            {
+                width = 512;
+                height = 256;
+            }
+            else if (rawLength < 256 * 1024)
+            {
+                width = 512;
+                height = 512;
+            }
+            else if (rawLength < 512 * 1024)
+            {
+                width = 512;
+                height = 1024;
+            }
+            else
+            {
+                width = 0;
+                height = 0;
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/OpenKh.Kh2/Contextes/FontContext.cs
+++ b/OpenKh.Kh2/Contextes/FontContext.cs
@@ -7,14 +7,18 @@ namespace OpenKh.Kh2.Contextes
     public class FontContext
     {
         private IImageRead imageSystem;
+        private IImageRead imageSystem2;
         private IImageRead imageEvent;
+        private IImageRead imageEvent2;
         private IImageRead imageIcon;
         private byte[] spacingSystem;
         private byte[] spacingEvent;
         private byte[] spacingIcon;
 
         public IImageRead ImageSystem { get => imageSystem; set => imageSystem = value; }
+        public IImageRead ImageSystem2 { get => imageSystem2; set => imageSystem2 = value; }
         public IImageRead ImageEvent { get => imageEvent; set => imageEvent = value; }
+        public IImageRead ImageEvent2 { get => imageEvent2; set => imageEvent2 = value; }
         public IImageRead ImageIcon { get => imageIcon; set => imageIcon = value; }
 
         public byte[] SpacingSystem { get => spacingSystem; set => spacingSystem = value; }
@@ -28,19 +32,19 @@ namespace OpenKh.Kh2.Contextes
                 switch (entry.Name)
                 {
                     case "sys":
-                        Read(entry, ref imageSystem, ref spacingSystem, false);
+                        ReadFont(entry, ref imageSystem, ref imageSystem2, ref spacingSystem);
                         break;
                     case "evt":
-                        Read(entry, ref imageEvent, ref spacingEvent, false);
+                        ReadFont(entry, ref imageEvent, ref imageEvent2, ref spacingEvent);
                         break;
                     case "icon":
-                        Read(entry, ref imageIcon, ref spacingIcon, 256, 160, true);
+                        ReadIcon(entry, ref imageIcon, ref spacingIcon, 256, 160);
                         break;
                 }
             }
         }
 
-        private void Read(Bar.Entry entry, ref IImageRead image, ref byte[] spacing, bool is8bit)
+        private void ReadFont(Bar.Entry entry, ref IImageRead image1, ref IImageRead image2, ref byte[] spacing)
         {
             switch (entry.Type)
             {
@@ -48,12 +52,15 @@ namespace OpenKh.Kh2.Contextes
                     spacing = ReadSpacing(entry);
                     break;
                 case Bar.EntryType.RawBitmap:
-                    image = ReadImage(entry, is8bit);
+                    entry.Stream.Position = 0;
+                    image1 = ReadImagePalette1(entry);
+                    entry.Stream.Position = 0;
+                    image2 = ReadImagePalette2(entry);
                     break;
             }
         }
 
-        private void Read(Bar.Entry entry, ref IImageRead image, ref byte[] spacing, int width, int height, bool is8bit)
+        private void ReadIcon(Bar.Entry entry, ref IImageRead image, ref byte[] spacing, int width, int height)
         {
             switch (entry.Type)
             {
@@ -61,7 +68,8 @@ namespace OpenKh.Kh2.Contextes
                     spacing = ReadSpacing(entry);
                     break;
                 case Bar.EntryType.RawBitmap:
-                    image = ReadImage(entry, width, height, is8bit);
+                    entry.Stream.Position = 0;
+                    image = ReadImage8bit(entry, width, height);
                     break;
             }
         }
@@ -71,15 +79,21 @@ namespace OpenKh.Kh2.Contextes
             return new BinaryReader(entry.Stream).ReadBytes((int)entry.Stream.Length);
         }
 
-        private static IImageRead ReadImage(Bar.Entry entry, bool is8bit)
+        private static IImageRead ReadImage8bit(Bar.Entry entry, int width, int height)
         {
-            DeductImageSize((int)entry.Stream.Length, out var width, out var height);
-            return ReadImage(entry, width, height, is8bit);
+            return RawBitmap.Read8bit(entry.Stream, width, height);
         }
 
-        private static IImageRead ReadImage(Bar.Entry entry, int width, int height, bool is8bit)
+        private static IImageRead ReadImagePalette1(Bar.Entry entry)
         {
-            return RawBitmap.Read(entry.Stream, width, height, is8bit);
+            DeductImageSize((int)entry.Stream.Length, out var width, out var height);
+            return RawBitmap.Read4bitPalette1(entry.Stream, width, height);
+        }
+
+        private static IImageRead ReadImagePalette2(Bar.Entry entry)
+        {
+            DeductImageSize((int)entry.Stream.Length, out var width, out var height);
+            return RawBitmap.Read4bitPalette2(entry.Stream, width, height);
         }
 
         private static bool DeductImageSize(int rawLength, out int width, out int height)

--- a/OpenKh.Kh2/Contextes/FontContext.cs
+++ b/OpenKh.Kh2/Contextes/FontContext.cs
@@ -1,0 +1,56 @@
+﻿using OpenKh.Imaging;
+using System.Collections.Generic;
+using System.IO;
+
+namespace OpenKh.Kh2.Contextes
+{
+    public class FontContext
+    {
+        private IImageRead imageSystem;
+        private IImageRead imageEvent;
+        private IImageRead imageIcon;
+        private byte[] spacingSystem;
+        private byte[] spacingEvent;
+        private byte[] spacingIcon;
+
+        public IImageRead ImageSystem { get => imageSystem; set => imageSystem = value; }
+        public IImageRead ImageEvent { get => imageEvent; set => imageEvent = value; }
+        public IImageRead ImageIcon { get => imageIcon; set => imageIcon = value; }
+
+        public byte[] SpacingSystem { get => spacingSystem; set => spacingSystem = value; }
+        public byte[] SpacingEvent { get => spacingEvent; set => spacingEvent = value; }
+        public byte[] SpacingIcon { get => spacingIcon; set => spacingIcon = value; }
+
+        public void Read(IEnumerable<Bar.Entry> entries)
+        {
+            foreach (var entry in entries)
+            {
+                switch (entry.Name)
+                {
+                    case "sys":
+                        Read(entry, ref imageSystem, ref spacingSystem, 512, 256, false);
+                        break;
+                    case "evt":
+                        Read(entry, ref imageEvent, ref spacingEvent, 512, 512, false);
+                        break;
+                    case "icon":
+                        Read(entry, ref imageIcon, ref spacingIcon, 256, 160, true);
+                        break;
+                }
+            }
+        }
+
+        private void Read(Bar.Entry entry, ref IImageRead image, ref byte[] spacing, int width, int height, bool is8bit)
+        {
+            switch (entry.Type)
+            {
+                case Bar.EntryType.Msg:
+                    spacing = new BinaryReader(entry.Stream).ReadBytes((int)entry.Stream.Length);
+                    break;
+                case Bar.EntryType.RawBitmap:
+                    image = RawBitmap.Read(entry.Stream, width, height, is8bit);
+                    break;
+            }
+        }
+    }
+}

--- a/OpenKh.Kh2/Imgd.cs
+++ b/OpenKh.Kh2/Imgd.cs
@@ -143,7 +143,7 @@ namespace OpenKh.Kh2
                 data[i * 4 + 0] = Clut[(i & 15) * 4 + 0];
                 data[i * 4 + 1] = Clut[(i & 15) * 4 + 1];
                 data[i * 4 + 2] = Clut[(i & 15) * 4 + 2];
-                data[i * 4 + 3] = FromPs2Alpha(Clut[(i & 15) * 4 + 3]);
+                data[i * 4 + 3] = Ps2.FromPs2Alpha(Clut[(i & 15) * 4 + 3]);
             }
 
             return data;
@@ -158,7 +158,7 @@ namespace OpenKh.Kh2
                 data[i * 4 + 0] = Clut[srcIndex * 4 + 0];
                 data[i * 4 + 1] = Clut[srcIndex * 4 + 1];
                 data[i * 4 + 2] = Clut[srcIndex * 4 + 2];
-                data[i * 4 + 3] = FromPs2Alpha(Clut[srcIndex * 4 + 3]);
+                data[i * 4 + 3] = Ps2.FromPs2Alpha(Clut[srcIndex * 4 + 3]);
             }
 
             return data;
@@ -172,7 +172,7 @@ namespace OpenKh.Kh2
                 newData[i + 0] = Data[i + 2];
                 newData[i + 1] = Data[i + 1];
                 newData[i + 2] = Data[i + 0];
-                newData[i + 3] = FromPs2Alpha(Data[i + 3]);
+                newData[i + 3] = Ps2.FromPs2Alpha(Data[i + 3]);
             }
 
             return newData;
@@ -186,8 +186,6 @@ namespace OpenKh.Kh2
 
             return pow;
         }
-
-        private byte FromPs2Alpha(byte alpha) => (byte)Math.Min(alpha * 2, byte.MaxValue);
 
         private static PixelFormat GetPixelFormat(int format)
         {

--- a/OpenKh.Kh2/Ps2.Utility.cs
+++ b/OpenKh.Kh2/Ps2.Utility.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace OpenKh.Kh2
+{
+    public partial class Ps2
+    {
+        public static byte FromPs2Alpha(byte alpha) =>
+            (byte)Math.Min(alpha * 2, byte.MaxValue);
+    }
+}

--- a/OpenKh.Kh2/RawBitmap.cs
+++ b/OpenKh.Kh2/RawBitmap.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Drawing;
+using System.IO;
+using OpenKh.Imaging;
+
+namespace OpenKh.Kh2
+{
+    public class RawBitmap : IImageRead
+    {
+        private const int PaletteCount = 256;
+        private const int BitsPerColor = 32;
+
+        private readonly byte[] _data;
+        private readonly byte[] _clut;
+
+        private RawBitmap(Stream stream, int width, int height)
+        {
+            Size = new Size(width, height);
+
+            var reader = new BinaryReader(stream);
+            _data = reader.ReadBytes(width * height);
+            _clut = reader.ReadBytes(PaletteCount * BitsPerColor / 8);
+        }
+
+        public Size Size { get; }
+
+        public PixelFormat PixelFormat => PixelFormat.Indexed8;
+
+        public byte[] GetClut()
+        {
+            var data = new byte[256 * 4];
+            for (var i = 0; i < 256; i++)
+            {
+                var srcIndex = Ps2.Repl(i);
+                data[i * 4 + 0] = _clut[srcIndex * 4 + 0];
+                data[i * 4 + 1] = _clut[srcIndex * 4 + 1];
+                data[i * 4 + 2] = _clut[srcIndex * 4 + 2];
+                data[i * 4 + 3] = Ps2.FromPs2Alpha(_clut[srcIndex * 4 + 3]);
+            }
+
+            return data;
+        }
+
+        public byte[] GetData() => _data;
+
+        public static RawBitmap Read(Stream stream, int width, int height) =>
+            new RawBitmap(stream, width, height);
+    }
+}

--- a/OpenKh.Tests/kh2/FontContextTests.cs
+++ b/OpenKh.Tests/kh2/FontContextTests.cs
@@ -11,23 +11,32 @@ namespace OpenKh.Tests.kh2
     {
         [Fact]
         public void LoadEnglishSystemFontTest() =>
-            LoadFontTest(512, 256, "sys", x => x.ImageSystem);
+            LoadFontTest(512, 256, 4, "sys", x => x.ImageSystem);
+
+        [Fact]
+        public void LoadJapaneseSystemFontTest() =>
+            LoadFontTest(512, 512, 4, "sys", x => x.ImageSystem);
 
         [Fact]
         public void LoadEnglishEventFontTest() =>
-            LoadFontTest(512, 512, "evt", x => x.ImageEvent);
+            LoadFontTest(512, 512, 4, "evt", x => x.ImageEvent);
+
+        [Fact]
+        public void LoadJapaneseEventFontTest() =>
+            LoadFontTest(512, 1024, 4, "evt", x => x.ImageEvent);
 
         [Fact]
         public void LoadIconFontTest() =>
-            LoadFontTest(256, 160, "icon", x => x.ImageIcon);
+            LoadFontTest(256, 160, 8, "icon", x => x.ImageIcon);
 
         private static void LoadFontTest(
             int expectedWidth,
             int expectedHeight,
+            int bitsPerPixel,
             string name,
             Func<FontContext, IImage> getter)
         {
-            var expectedLength = expectedWidth * expectedHeight;
+            var expectedLength = expectedWidth * expectedHeight * bitsPerPixel / 8;
 
             var fontContext = new FontContext();
             var entry = new Bar.Entry
@@ -50,6 +59,7 @@ namespace OpenKh.Tests.kh2
         {
             var stream = new MemoryStream(length);
             stream.Write(new byte[length]);
+            stream.Position = 0;
 
             return stream;
         }

--- a/OpenKh.Tests/kh2/FontContextTests.cs
+++ b/OpenKh.Tests/kh2/FontContextTests.cs
@@ -1,0 +1,57 @@
+﻿using OpenKh.Imaging;
+using OpenKh.Kh2;
+using OpenKh.Kh2.Contextes;
+using System;
+using System.IO;
+using Xunit;
+
+namespace OpenKh.Tests.kh2
+{
+    public class FontContextTests
+    {
+        [Fact]
+        public void LoadEnglishSystemFontTest() =>
+            LoadFontTest(512, 256, "sys", x => x.ImageSystem);
+
+        [Fact]
+        public void LoadEnglishEventFontTest() =>
+            LoadFontTest(512, 512, "evt", x => x.ImageEvent);
+
+        [Fact]
+        public void LoadIconFontTest() =>
+            LoadFontTest(256, 160, "icon", x => x.ImageIcon);
+
+        private static void LoadFontTest(
+            int expectedWidth,
+            int expectedHeight,
+            string name,
+            Func<FontContext, IImage> getter)
+        {
+            var expectedLength = expectedWidth * expectedHeight;
+
+            var fontContext = new FontContext();
+            var entry = new Bar.Entry
+            {
+                Name = name,
+                Type = Bar.EntryType.RawBitmap,
+                Stream = CreateStream(expectedLength)
+            };
+
+            fontContext.Read(new Bar.Entry[] { entry });
+
+            var image = getter(fontContext);
+            Assert.NotNull(image);
+            Assert.Equal(expectedWidth, image.Size.Width);
+            Assert.Equal(expectedHeight, image.Size.Height);
+            Assert.Equal(expectedLength, entry.Stream.Position);
+        }
+
+        private static Stream CreateStream(int length)
+        {
+            var stream = new MemoryStream(length);
+            stream.Write(new byte[length]);
+
+            return stream;
+        }
+    }
+}

--- a/OpenKh.Tests/kh2/FontContextTests.cs
+++ b/OpenKh.Tests/kh2/FontContextTests.cs
@@ -10,20 +10,32 @@ namespace OpenKh.Tests.kh2
     public class FontContextTests
     {
         [Fact]
-        public void LoadEnglishSystemFontTest() =>
+        public void LoadEnglishSystemFontTest()
+        {
             LoadFontTest(512, 256, 4, "sys", x => x.ImageSystem);
+            LoadFontTest(512, 256, 4, "sys", x => x.ImageSystem2);
+        }
 
         [Fact]
-        public void LoadJapaneseSystemFontTest() =>
+        public void LoadJapaneseSystemFontTest()
+        {
             LoadFontTest(512, 512, 4, "sys", x => x.ImageSystem);
+            LoadFontTest(512, 512, 4, "sys", x => x.ImageSystem2);
+        }
 
         [Fact]
-        public void LoadEnglishEventFontTest() =>
+        public void LoadEnglishEventFontTest()
+        {
             LoadFontTest(512, 512, 4, "evt", x => x.ImageEvent);
+            LoadFontTest(512, 512, 4, "evt", x => x.ImageEvent2);
+        }
 
         [Fact]
-        public void LoadJapaneseEventFontTest() =>
+        public void LoadJapaneseEventFontTest()
+        {
             LoadFontTest(512, 1024, 4, "evt", x => x.ImageEvent);
+            LoadFontTest(512, 1024, 4, "evt", x => x.ImageEvent2);
+        }
 
         [Fact]
         public void LoadIconFontTest() =>


### PR DESCRIPTION
* Add RawBitmap support for 4 bit and 8 bit images
* Centralize in one point the loading of US and JP fonts
* Complete JP font support
* Spacing support

This will be very useful for the rendering support