### PR TITLE
misc fixes on bar docs

### DIFF
--- a/docs/kh2/file/type/bar.md
+++ b/docs/kh2/file/type/bar.md
@@ -16,16 +16,17 @@ All the values are Little Endian in the PS2/PS4 Versions, while they are Big End
 
 | Offset | Variable Type | Description |
 |--------|---------------|-------------|
-| 0 | int32_t | The identifier of the file (Should be always 0x01524142) |
-| 4 | int32_t | The sub-file count of the BAR File. |
-| 8 | int32_t | Always zero. Has no known effects.
-| 8 | int32_t | Unknown. Often 0. Some mset files set it to 1 or 2.
+| 0 | char[4] | The identifier of the file (Should be always 0x01524142) |
+| 4 | uint32_t | The sub-file count of the BAR File. |
+| 8 | uint32_t | Always zero. Padding for a lookup address at runtime. 
+| 12 | int32_t | Unknown. Often 0. Some mset files set it to 1 or 2.
 
 ### BAR Entry
 
 | Offset | Variable Type | Description |
 |--------|---------------|-------------|
-| 0 | int32_t | The sub-file's type (List given below) |
+| 0 | uint16_t | The sub-file's type (List given below) |
+| 2 | uint16_t | Duplicate flag (if the entry is already included in the BAR) |
 | 4 | char[4] | The name of the sub-file. Empty characters are registered as 0x00.|
 | 8 | uint32_t | Sub-file's offset/location. Must be divisible by 0x10. Can be padded. |
 | 12 | uint32_t | Sub-file's size. Everything that comes after [ offset + size ] will be ignored for that specific sub-file.
@@ -46,10 +47,10 @@ Keep in mind that this list is still incomplete and will be changed over the cou
 | 1 | Binary Archive | Varies.
 | 2 | Independent Format (ItemList, TreasureList, StringList, etc.) | 03system.bin (Varies) - msg/jp/xxx.bar (Always StringList)
 | 3 | AI Code (Also should not be used, unless you can code an AI) | MDLX - ARD - MAG
-| 4 | VIF Data (Vertices, Skinning, Bones, etc.) | MDLX - MAP
+| 4 | 3D Model data (Encapsulated VIF packets containing Vertices, Skinning, Bones for MDLX, etc.) | MDLX - MAP
 | 5 | Mesh Occlusion/Obstruction (Probably Culling) | MAP
 | 6 | Map Collision Data | MAP 
-| 7 | RAW Texture Data | MDLX - MAP
+| 7 | RAW(TIM2) Texture Data | MDLX - MAP
 | 8 | DPX (A bit unknown) | PAX
 | 9 | Animation Data | ANB
 | 10 | Texture Data | MAP - minigame/xxx.bar


### PR DESCRIPTION
Excuse me in advance for this long PR and semi off-topic questions below, I tried to keep this as professional as possible.
 
* the type is only a uint16, it can contain a duplicate flag
* type 0x04 is not composed solely of VIF packets, albeit mostly, refer to my old tools for more details on their inner workings
* the zero value is a lookup address used at runtime

Keep in mind all of this was done through memory, so someone would have to double check this info i guess.

On another note don't you think something like a [kaitai](http://kaitai.io/) setup would be much more explicit for structures? That would allow you to get a parser for free on top of auto-generated docs ( I will avoid to start an argument about other technologies used by the project and only mention it can output C# )

Also any reason why most documented formats are not documented anywhere in this project? Not enough workforce? I am curious about this point since most formats have been extensively documented in the past.

By the way, unlike what you mentionned on twitter, AI, PAX, ANB and spawn points have been mostly reversed:
* Spawn points are available in kkdf2 tools from ages ago
* Several disassemblers have been made privately for KH2 AI. The AI is a small stack-based variable-width ISA with a huge number of "syscalls" if we can call them this way, which are by large the main reason AI reversing is such a pain
* ANBs has been mostly reversed by kkdf2 ten years ago again, with added information from soraiko and I
* While I did not worked myself on the PAX format, I remember some old effort about that in the KH groups.

To aid in reversing, RECOM BETA ISO is compiled in debug mode and some of its symbols can be reused. For example, the whole dpd logic basically has not changed _at all_ so this might have helped the reversing effort. Ghidra also has a work-in-progress [_decompiler_](https://github.com/beardypig/ghidra-emotionengine), which I would encourage you to look into since it can ease up immensely some reversing time(it is nowhere near perfect, but gets some basic tasks done). Ghidra SLEIGH specification is to keep in mind in cases like this, since you basically get a free decompiler when making a disassembler.

Anyways, sorry about the whole off-topic parts of the PR.
Cheers,
-G

 