### PR TITLE
Initial KH1 Documentation

### DIFF
--- a/docs/kh1/file-type.md
+++ b/docs/kh1/file-type.md
@@ -1,0 +1,58 @@
+# Kingdom Hearts I File Types
+
+| Extension | Description | Tool |
+|-----------|-------------|------|
+| AML | TARC Archive; example: gumi/gumi.aml
+| AMO | Unknown; example: gumi/gumi.amo
+| ARD | Room Archive; example: aw04.ard
+| BGM | Midi-like file; example: amusic/music097.bgm
+| BIN | World Binary Data; example: aw00\_01.bin
+| BIN (1) | Unknown; example: btlbtl.bin
+| BIN (2) | RAW (TIM2) Image; example: command2/uitex.bin
+| BIN (3) | Unknown; example: menu/mc\_icon.bin
+| BIN (4) | Unknown; example: menu/sysmsg.bin
+| BIN (5) | Unknown; example: worldmap/gevent.bin
+| BIN (6) | Unknown; example: worldmap/gptolp.bin
+| BIN (7) | Unknown; example: worldmap/ins.bin
+| BIN (8) | Unknown; example: worldmap/SAWDMSG.BIN
+| BIN (9) | Unknown; example: worldmap/ev/wp\_1000.bin
+| BIN (10) | Unknown; example: worldmap/world\_ini.bin
+| DAT | Pre-rendered Movie Data; example: demo.dat
+| DAT (1) | Unknown; example: xs\_bambi.dat
+| DAT (2) | Binary Wrapper for BGM; example: amusic/music100.dat
+| DAT (3) | Sound Effect Data, somewhat similar to SE file; example: eventse/al\_002.dat
+| DAT (4) | TARC Binary Archive; example: worldmap/challe.dat
+| DBT | Unknown; example: xs\_bambi.dbt
+| DPP | Unknown; example: eveffect/al/al\_000.dpp
+| DPX | Special Effects; example: nm08.dpx
+| EV | Unknown; example: gameover.ev
+| EVM | Unknown; example: al01\_al011.evm
+| IMG | World Image Data; example: aw00\_01.img
+| IMG (1) | Raw (TIM2) Image Archive; example: title/title.img
+| KMB | Unknown; example: menu/md\_anthem.kmb
+| KNA | Unknown; example: worldmap/test/dc\_1047.kna
+| KNJ | Unknown; example: kanji.knj
+| KNM | Unknown; example: worldmap/test/dc\_1047.knm
+| MAG | Magic Data; example: xm\_fire\_01.mag
+| MDLS | Model Data; example: xa\_ex\_0010.mdls
+| MLB | Unknown; example: worldmap/wi/wp\_1000.mlb
+| MSET | Moveset Data; example: xa\_ex\_0010.mset
+| NAM | Unknown; example: allarea.nam
+| PNG | Portable Network Graphic Image; example: gumi/jkt\_001.png
+| PS2 | World Map Image Data; example: worldmap/world.ps2
+| RGB | Raw Image Data; example: image/dc\_001.rgb
+| RTB | Gumi Route Data; example: worldmap/route\_al\_1.rtb
+| SE | Sound Effects Data; example: xw\_ex\_5010.se
+| SET | Unknown; example: allset.set
+| SYS | Unknown; example: gumi/info.sys
+| TM2 | TIM2 Image; example: title/copyright.tm2
+| TZB | TEZB Image Archive; example: worldmap/gm\_clear.tzb
+| VAG | Streamed Music or voice
+| VM | Unknown; example: amusic/vo000000.vm
+| VSB | Character Voices Contains VAG; example: voice/al\_donald.vsb 
+| VSET | Cutscene Sounds Contains VAG; example: voice/event/al/al\_001.vset
+| WD | Instruments for BGM and other sound formats; example: amusic/wave0099.wd
+| WDT | World Data; example: al.wdt
+| WPN | Weapon Model Data; example: xw\_ex\_5010.wpn
+| X | Unknown; example: dkmovie.x
+

--- a/docs/kh1/index.md
+++ b/docs/kh1/index.md
@@ -1,0 +1,7 @@
+# Kingdom Hearts I
+
+## General Documentation
+
+* [Worlds](worlds.md)
+* [File Types](file-type.md)
+

--- a/docs/kh1/worlds.md
+++ b/docs/kh1/worlds.md
@@ -1,0 +1,22 @@
+# Kingdom Hearts I - Worlds
+
+| Id | World |
+|----|-------|
+| AL | Agrabah
+| AW | Wonderland
+| DC | Disney Castle
+| DH | Dive to Heart
+| DI | Destiny Island
+| EW | End of the World
+| GB | Unknown
+| HE | Olympus Coliseum
+| LM | Atlantica
+| NM | Halloweentown
+| PC | Hollow Bastion
+| PI | Monstro
+| PO | 100 Acre Wood
+| PP | Neverland
+| TW | Traverse Town
+| TZ | Deep Jungle
+| ZZ | Miscellaneous
+

--- a/docs/kh2/file-type.md
+++ b/docs/kh2/file-type.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts I & II file types
+# Kingdom Hearts II file types
 
 | Extension | Description | Tool | 
 |-----------|-------------|------|


### PR DESCRIPTION
Added Initial files for KH1 documentation with a similar format to the existing KH2 documentation.
Modified file-type.md in the KH2 documentation so that its title no longer says KH1 in it, since the KH1 documentation has been placed in its own folder and I don't believe it makes sense for the file types of multiple games to be tracked together.