### PR TITLE
Revert "Imgd.Create now inverts correctly the blue and red channels"

### DIFF
--- a/OpenKh.Kh2/Imgd.Create.cs
+++ b/OpenKh.Kh2/Imgd.Create.cs
@@ -34,8 +34,6 @@ namespace OpenKh.Kh2
                 Data = data;
             }
 
-            Data = ImageDataHelpers.GetInvertedRedBlueChannels(Data, Size, PixelFormat);
-
             switch (format)
             {
                 case Format4bpp:


### PR DESCRIPTION
This reverts a change that caused some tests failing due to Imgd.Create that was creating Imgd textures with red and blue channels swapped