### PR TITLE
Redirect from CopyMemory to memcpy.

### DIFF
--- a/OpenKh.Tools.Common/Controls/DrawPanel.cs
+++ b/OpenKh.Tools.Common/Controls/DrawPanel.cs
@@ -13,8 +13,14 @@ namespace OpenKh.Tools.Common.Controls
 {
     public class DrawPanel : FrameworkElement
     {
-        [DllImport("kernel32.dll", EntryPoint = nameof(CopyMemory), SetLastError = false)]
-        private static extern void CopyMemory(IntPtr dest, IntPtr src, int count);
+        private static void CopyMemory(IntPtr dest, IntPtr src, int count)
+        {
+            memcpy(dest, src, new UIntPtr(Convert.ToUInt32(count)));
+        }
+
+        [DllImport("msvcrt.dll", EntryPoint = "memcpy", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
+        private static extern IntPtr memcpy(IntPtr dest, IntPtr src, UIntPtr count);
+
 
         public static readonly DependencyProperty DrawingProperty =
             GetDependencyProperty<DrawPanel, IDrawing>(nameof(Drawing),(o, x) => o.SetDrawing(x));


### PR DESCRIPTION
When I launched OpenKh.Tools.Kh2TextEditor, System.EntryPointNotFoundException raised.

![2020-05-23_10h44_56](https://user-images.githubusercontent.com/5955540/82719112-ac91ce00-9ce2-11ea-9d2f-a8a39fe13b34.png)

In this is small patch, it uses P/Invoke [memcpy](http://pinvoke.net/default.aspx/msvcrt/memcpy.html) in msvcrt.dll.