### PR TITLE
Set default value to BackgroundColor

### DIFF
--- a/OpenKh.Tools.LayoutViewer/Properties/Settings.Designer.cs
+++ b/OpenKh.Tools.LayoutViewer/Properties/Settings.Designer.cs
@@ -25,6 +25,7 @@ namespace OpenKh.Tools.LayoutViewer {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValue("Magenta")]
         public global::System.Drawing.Color BackgroundColor {
             get {
                 return ((global::System.Drawing.Color)(this["BackgroundColor"]));


### PR DESCRIPTION
Fix start up problem of LayoutViewer on launching via Visual Studio 2019: `System.NullReferenceException: 'Object reference not set to an instance of an object.'`

![2020-05-23_11h29_09](https://user-images.githubusercontent.com/5955540/82719786-aef72680-9ce8-11ea-9af2-288a90197370.png)

Fix #109 