### PR TITLE
Add custom shader to simulate PS2 behaviours

### DIFF
--- a/OpenKh.Game/Content/KingdomShader.fx
+++ b/OpenKh.Game/Content/KingdomShader.fx
@@ -9,6 +9,7 @@
 
 matrix WorldView;
 matrix ProjectionView;
+float4 TextureRegion;
 Texture2D Texture0;
 
 sampler2D TextureSampler = sampler_state
@@ -30,6 +31,22 @@ struct VertexShaderOutput
 	float2 TextureUv : TEXCOORD0;
 };
 
+float2 RegionClamp(float2 textureCoord)
+{
+	return float2(
+		min(max(textureCoord.x, TextureRegion.x), TextureRegion.z),
+		min(max(textureCoord.y, TextureRegion.y), TextureRegion.w)
+		);
+}
+
+float2 RegionRepeat(float2 textureCoord)
+{
+	return float2(
+		((textureCoord.x - TextureRegion.x) % (TextureRegion.z - TextureRegion.x)) + TextureRegion.x,
+		((textureCoord.y - TextureRegion.y) % (TextureRegion.w - TextureRegion.y)) + TextureRegion.y
+		);
+}
+
 VertexShaderOutput MainVS(in VertexShaderInput input)
 {
 	VertexShaderOutput output = (VertexShaderOutput)0;
@@ -43,7 +60,7 @@ VertexShaderOutput MainVS(in VertexShaderInput input)
 
 float4 MainPS(VertexShaderOutput input) : COLOR
 {
-	float4 tex = tex2D(TextureSampler, input.TextureUv);
+	float4 tex = tex2D(TextureSampler, RegionRepeat(input.TextureUv));
 	return tex * input.Color;
 }
 

--- a/OpenKh.Game/Content/KingdomShader.fx
+++ b/OpenKh.Game/Content/KingdomShader.fx
@@ -41,7 +41,7 @@ float RegionClamp(float value, float valueMin, float valueMax)
 
 float RegionRepeat(float value, float min, float max)
 {
-	return ((value - min) % (max - min)) + min;
+	return (value % (max - min)) + min;
 }
 
 float ApplyTextureWrap(float value, int mode, float min, float max) {

--- a/OpenKh.Game/Content/KingdomShader.fx
+++ b/OpenKh.Game/Content/KingdomShader.fx
@@ -7,7 +7,8 @@
 	#define PS_SHADERMODEL ps_4_0_level_9_1
 #endif
 
-matrix WorldViewProjection;
+matrix WorldView;
+matrix ProjectionView;
 Texture2D Texture0;
 
 sampler2D TextureSampler = sampler_state
@@ -33,7 +34,7 @@ VertexShaderOutput MainVS(in VertexShaderInput input)
 {
 	VertexShaderOutput output = (VertexShaderOutput)0;
 
-	output.Position = mul(input.Position, WorldViewProjection);
+	output.Position = mul(mul(input.Position, WorldView), ProjectionView);
 	output.TextureUv = input.TextureUv;
 	output.Color = input.Color;
 

--- a/OpenKh.Game/Models/Mesh.cs
+++ b/OpenKh.Game/Models/Mesh.cs
@@ -2,7 +2,6 @@
 using Microsoft.Xna.Framework.Graphics;
 using OpenKh.Kh2;
 using System;
-using System.Drawing;
 
 namespace OpenKh.Game.Models
 {
@@ -19,13 +18,11 @@ namespace OpenKh.Game.Models
 
         public Vector2 RegionU => new Vector2(
             (float)Math.Min(ModelTexture.TextureAddressMode.Left, ModelTexture.TextureAddressMode.Right) / Texture2D.Width,
-            (float)Math.Max(ModelTexture.TextureAddressMode.Left, ModelTexture.TextureAddressMode.Right) / Texture2D.Width
-            );
+            (float)Math.Max(ModelTexture.TextureAddressMode.Left, ModelTexture.TextureAddressMode.Right) / Texture2D.Width);
 
         public Vector2 RegionV => new Vector2(
             (float)Math.Min(ModelTexture.TextureAddressMode.Top, ModelTexture.TextureAddressMode.Bottom) / Texture2D.Height,
-            (float)Math.Max(ModelTexture.TextureAddressMode.Top, ModelTexture.TextureAddressMode.Bottom) / Texture2D.Height
-            );
+            (float)Math.Max(ModelTexture.TextureAddressMode.Top, ModelTexture.TextureAddressMode.Bottom) / Texture2D.Height);
 
         public void Dispose()
         {

--- a/OpenKh.Game/Models/Mesh.cs
+++ b/OpenKh.Game/Models/Mesh.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using OpenKh.Kh2;
 using System;
 using System.Drawing;
@@ -15,10 +16,14 @@ namespace OpenKh.Game.Models
 
         public ModelTexture.Texture ModelTexture { get; }
         public Texture2D Texture2D { get; }
-        public RectangleF Region => RectangleF.FromLTRB(
+
+        public Vector2 RegionU => new Vector2(
             (float)Math.Min(ModelTexture.TextureAddressMode.Left, ModelTexture.TextureAddressMode.Right) / Texture2D.Width,
+            (float)Math.Max(ModelTexture.TextureAddressMode.Left, ModelTexture.TextureAddressMode.Right) / Texture2D.Width
+            );
+
+        public Vector2 RegionV => new Vector2(
             (float)Math.Min(ModelTexture.TextureAddressMode.Top, ModelTexture.TextureAddressMode.Bottom) / Texture2D.Height,
-            (float)Math.Max(ModelTexture.TextureAddressMode.Left, ModelTexture.TextureAddressMode.Right) / Texture2D.Width,
             (float)Math.Max(ModelTexture.TextureAddressMode.Top, ModelTexture.TextureAddressMode.Bottom) / Texture2D.Height
             );
 

--- a/OpenKh.Game/Models/Mesh.cs
+++ b/OpenKh.Game/Models/Mesh.cs
@@ -1,7 +1,33 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
+using OpenKh.Kh2;
+using System;
+using System.Drawing;
 
 namespace OpenKh.Game.Models
 {
+    public class KingdomTexture : IDisposable
+    {
+        public KingdomTexture(ModelTexture.Texture texture, GraphicsDevice graphics)
+        {
+            ModelTexture = texture;
+            Texture2D = texture.CreateTexture(graphics);
+        }
+
+        public ModelTexture.Texture ModelTexture { get; }
+        public Texture2D Texture2D { get; }
+        public RectangleF Region => RectangleF.FromLTRB(
+            (float)Math.Min(ModelTexture.TextureAddressMode.Left, ModelTexture.TextureAddressMode.Right) / Texture2D.Width,
+            (float)Math.Min(ModelTexture.TextureAddressMode.Top, ModelTexture.TextureAddressMode.Bottom) / Texture2D.Height,
+            (float)Math.Max(ModelTexture.TextureAddressMode.Left, ModelTexture.TextureAddressMode.Right) / Texture2D.Width,
+            (float)Math.Max(ModelTexture.TextureAddressMode.Top, ModelTexture.TextureAddressMode.Bottom) / Texture2D.Height
+            );
+
+        public void Dispose()
+        {
+            Texture2D?.Dispose();
+        }
+    }
+
     public class Mesh
     {
         public class Segment
@@ -18,6 +44,6 @@ namespace OpenKh.Game.Models
 
         public Segment[] Segments { get; set; }
         public Part[] Parts { get; set; }
-        public Texture2D[] Textures { get; set; }
+        public KingdomTexture[] Textures { get; set; }
     }
 }

--- a/OpenKh.Game/MonoDrawing.cs
+++ b/OpenKh.Game/MonoDrawing.cs
@@ -74,10 +74,10 @@ namespace OpenKh.Game
         private Texture2D _texture;
         private int _currentSpriteIndex;
 
-        public xnaf.Matrix WorldViewProjection
+        public xnaf.Matrix ProjectionView
         {
-            get => _shader.WorldViewProjection;
-            set => _shader.WorldViewProjection = value;
+            get => _shader.ProjectionView;
+            set => _shader.ProjectionView = value;
         }
         public Texture2D Texture0
         {
@@ -203,7 +203,7 @@ namespace OpenKh.Game
             _shader.Pass(pass =>
             {
                 Texture0 = _texture;
-                WorldViewProjection = xnaf.Matrix.CreateOrthographicOffCenter(0, 512, 416, 0, -1000.0f, +1000.0f);
+                ProjectionView = xnaf.Matrix.CreateOrthographicOffCenter(0, 512, 416, 0, -1000.0f, +1000.0f);
                 pass.Apply();
 
                 GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, _currentSpriteIndex * 2);

--- a/OpenKh.Game/MonoDrawing.cs
+++ b/OpenKh.Game/MonoDrawing.cs
@@ -204,6 +204,8 @@ namespace OpenKh.Game
             {
                 Texture0 = _texture;
                 ProjectionView = xnaf.Matrix.CreateOrthographicOffCenter(0, 512, 416, 0, -1000.0f, +1000.0f);
+                _shader.WorldView = xnaf.Matrix.Identity;
+                _shader.TextureRegion = new RectangleF(0, 0, 1, 1);
                 pass.Apply();
 
                 GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, _currentSpriteIndex * 2);

--- a/OpenKh.Game/MonoDrawing.cs
+++ b/OpenKh.Game/MonoDrawing.cs
@@ -205,7 +205,10 @@ namespace OpenKh.Game
                 Texture0 = _texture;
                 ProjectionView = xnaf.Matrix.CreateOrthographicOffCenter(0, 512, 416, 0, -1000.0f, +1000.0f);
                 _shader.WorldView = xnaf.Matrix.Identity;
-                _shader.TextureRegion = new RectangleF(0, 0, 1, 1);
+                _shader.TextureRegionU = KingdomShader.DefaultTextureRegion;
+                _shader.TextureRegionV = KingdomShader.DefaultTextureRegion;
+                _shader.TextureWrapModeU = TextureWrapMode.Clamp;
+                _shader.TextureWrapModeV = TextureWrapMode.Clamp;
                 pass.Apply();
 
                 GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, _currentSpriteIndex * 2);

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -1,11 +1,9 @@
-﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework;
 using OpenKh.Common;
 using OpenKh.Game.DataContent;
 using OpenKh.Game.Debugging;
 using OpenKh.Game.Infrastructure;
 using OpenKh.Game.States;
-using OpenKh.Kh2;
 using System.IO;
 
 namespace OpenKh.Game

--- a/OpenKh.Game/Shaders/KingdomShader.cs
+++ b/OpenKh.Game/Shaders/KingdomShader.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+
+namespace OpenKh.Game.Shaders
+{
+    public class KingdomShader : IDisposable
+    {
+        private readonly EffectParameter _parameterWorldViewProjection;
+        private readonly EffectParameter _parameterTexture0;
+
+        public KingdomShader(ContentManager contentManager)
+        {
+            Effect = contentManager.Load<Effect>("KingdomShader");
+            _parameterTexture0 = Effect.Parameters["Texture0"];
+            _parameterWorldViewProjection = Effect.Parameters["WorldViewProjection"];
+        }
+
+        public Effect Effect { get; }
+
+        public Matrix WorldViewProjection
+        {
+            get => _parameterWorldViewProjection.GetValueMatrix();
+            set => _parameterWorldViewProjection.SetValue(value);
+        }
+
+        public Texture2D Texture0
+        {
+            get => _parameterTexture0.GetValueTexture2D();
+            set => _parameterTexture0.SetValue(value);
+        }
+
+        public void Pass(Action<EffectPass> action)
+        {
+            foreach (var pass in Effect.CurrentTechnique.Passes)
+                action(pass);
+        }
+
+        public void Dispose()
+        {
+            Effect?.Dispose();
+        }
+    }
+}

--- a/OpenKh.Game/Shaders/KingdomShader.cs
+++ b/OpenKh.Game/Shaders/KingdomShader.cs
@@ -2,13 +2,17 @@
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Drawing;
 
 namespace OpenKh.Game.Shaders
 {
     public class KingdomShader : IDisposable
     {
+        public static readonly RectangleF DefaultTextureRegion = new RectangleF(0, 0, 1, 1);
+
         private readonly EffectParameter _worldViewParameter;
         private readonly EffectParameter _projectionViewParameter;
+        private readonly EffectParameter _parameterTextureRegion;
         private readonly EffectParameter _parameterTexture0;
 
         public KingdomShader(ContentManager contentManager)
@@ -16,10 +20,12 @@ namespace OpenKh.Game.Shaders
             Effect = contentManager.Load<Effect>("KingdomShader");
             _worldViewParameter = Effect.Parameters["WorldView"];
             _projectionViewParameter = Effect.Parameters["ProjectionView"];
+            _parameterTextureRegion = Effect.Parameters["TextureRegion"];
             _parameterTexture0 = Effect.Parameters["Texture0"];
 
             WorldView = Matrix.Identity;
             ProjectionView = Matrix.Identity;
+            TextureRegion = DefaultTextureRegion;
         }
 
         public Effect Effect { get; }
@@ -40,6 +46,18 @@ namespace OpenKh.Game.Shaders
         {
             get => _parameterTexture0.GetValueTexture2D();
             set => _parameterTexture0.SetValue(value);
+        }
+
+        public RectangleF TextureRegion
+        {
+            get
+            {
+                var value = _parameterTextureRegion.GetValueVector4();
+                return RectangleF.FromLTRB(value.X, value.Y, value.Z, value.W);
+            }
+
+            set => _parameterTextureRegion.SetValue(
+                new Vector4(value.Left, value.Top, value.Right, value.Bottom));
         }
 
         public void Pass(Action<EffectPass> action)

--- a/OpenKh.Game/Shaders/KingdomShader.cs
+++ b/OpenKh.Game/Shaders/KingdomShader.cs
@@ -6,13 +6,22 @@ using System.Drawing;
 
 namespace OpenKh.Game.Shaders
 {
+    public enum TextureWrapMode
+    {
+        Clamp = 1,
+        Repeat = 2,
+    }
+
     public class KingdomShader : IDisposable
     {
-        public static readonly RectangleF DefaultTextureRegion = new RectangleF(0, 0, 1, 1);
+        public static readonly Vector2 DefaultTextureRegion = new Vector2(0, 1);
 
         private readonly EffectParameter _worldViewParameter;
         private readonly EffectParameter _projectionViewParameter;
-        private readonly EffectParameter _parameterTextureRegion;
+        private readonly EffectParameter _parameterTextureRegionU;
+        private readonly EffectParameter _parameterTextureRegionV;
+        private readonly EffectParameter _parameterTextureWrapModeU;
+        private readonly EffectParameter _parameterTextureWrapModeV;
         private readonly EffectParameter _parameterTexture0;
 
         public KingdomShader(ContentManager contentManager)
@@ -20,12 +29,18 @@ namespace OpenKh.Game.Shaders
             Effect = contentManager.Load<Effect>("KingdomShader");
             _worldViewParameter = Effect.Parameters["WorldView"];
             _projectionViewParameter = Effect.Parameters["ProjectionView"];
-            _parameterTextureRegion = Effect.Parameters["TextureRegion"];
+            _parameterTextureRegionU = Effect.Parameters["TextureRegionU"];
+            _parameterTextureRegionV = Effect.Parameters["TextureRegionV"];
+            _parameterTextureWrapModeU = Effect.Parameters["TextureWrapModeU"];
+            _parameterTextureWrapModeV = Effect.Parameters["TextureWrapModeV"];
             _parameterTexture0 = Effect.Parameters["Texture0"];
 
             WorldView = Matrix.Identity;
             ProjectionView = Matrix.Identity;
-            TextureRegion = DefaultTextureRegion;
+            TextureRegionU = DefaultTextureRegion;
+            TextureRegionV = DefaultTextureRegion;
+            TextureWrapModeU = TextureWrapMode.Clamp;
+            TextureWrapModeV = TextureWrapMode.Clamp;
         }
 
         public Effect Effect { get; }
@@ -48,16 +63,27 @@ namespace OpenKh.Game.Shaders
             set => _parameterTexture0.SetValue(value);
         }
 
-        public RectangleF TextureRegion
+        public Vector2 TextureRegionU
         {
-            get
-            {
-                var value = _parameterTextureRegion.GetValueVector4();
-                return RectangleF.FromLTRB(value.X, value.Y, value.Z, value.W);
-            }
+            get => _parameterTextureRegionU.GetValueVector2();
+            set => _parameterTextureRegionU.SetValue(value);
+        }
+        public Vector2 TextureRegionV
+        {
+            get => _parameterTextureRegionV.GetValueVector2();
+            set => _parameterTextureRegionV.SetValue(value);
+        }
 
-            set => _parameterTextureRegion.SetValue(
-                new Vector4(value.Left, value.Top, value.Right, value.Bottom));
+        public TextureWrapMode TextureWrapModeU
+        {
+            get => (TextureWrapMode)_parameterTextureWrapModeU.GetValueInt32();
+            set => _parameterTextureWrapModeU.SetValue((int)value);
+        }
+
+        public TextureWrapMode TextureWrapModeV
+        {
+            get => (TextureWrapMode)_parameterTextureWrapModeV.GetValueInt32();
+            set => _parameterTextureWrapModeV.SetValue((int)value);
         }
 
         public void Pass(Action<EffectPass> action)

--- a/OpenKh.Game/Shaders/KingdomShader.cs
+++ b/OpenKh.Game/Shaders/KingdomShader.cs
@@ -7,22 +7,33 @@ namespace OpenKh.Game.Shaders
 {
     public class KingdomShader : IDisposable
     {
-        private readonly EffectParameter _parameterWorldViewProjection;
+        private readonly EffectParameter _worldViewParameter;
+        private readonly EffectParameter _projectionViewParameter;
         private readonly EffectParameter _parameterTexture0;
 
         public KingdomShader(ContentManager contentManager)
         {
             Effect = contentManager.Load<Effect>("KingdomShader");
+            _worldViewParameter = Effect.Parameters["WorldView"];
+            _projectionViewParameter = Effect.Parameters["ProjectionView"];
             _parameterTexture0 = Effect.Parameters["Texture0"];
-            _parameterWorldViewProjection = Effect.Parameters["WorldViewProjection"];
+
+            WorldView = Matrix.Identity;
+            ProjectionView = Matrix.Identity;
         }
 
         public Effect Effect { get; }
 
-        public Matrix WorldViewProjection
+        public Matrix WorldView
         {
-            get => _parameterWorldViewProjection.GetValueMatrix();
-            set => _parameterWorldViewProjection.SetValue(value);
+            get => _worldViewParameter.GetValueMatrix();
+            set => _worldViewParameter.SetValue(value);
+        }
+
+        public Matrix ProjectionView
+        {
+            get => _projectionViewParameter.GetValueMatrix();
+            set => _projectionViewParameter.SetValue(value);
         }
 
         public Texture2D Texture0

--- a/OpenKh.Game/States/MapState.cs
+++ b/OpenKh.Game/States/MapState.cs
@@ -161,8 +161,7 @@ namespace OpenKh.Game.States
         {
             _models.Clear();
             LoadMap(_worldId, _placeId);
-            //LoadObjEntry("F_LM670_MATSU");
-            LoadObjEntry("P_EX100");
+            LoadObjEntry(_objEntryId);
         }
 
         private void LoadObjEntry(string name)

--- a/OpenKh.Game/States/MapState.cs
+++ b/OpenKh.Game/States/MapState.cs
@@ -99,7 +99,45 @@ namespace OpenKh.Game.States
                             if (_shader.Texture0 != texture.Texture2D)
                             {
                                 _shader.Texture0 = texture.Texture2D;
-                                _shader.TextureRegion = texture.Region;
+                                switch (texture.ModelTexture.TextureAddressMode.AddressU)
+                                {
+                                    case ModelTexture.TextureWrapMode.Clamp:
+                                        _shader.TextureRegionU = KingdomShader.DefaultTextureRegion;
+                                        _shader.TextureWrapModeU = TextureWrapMode.Clamp;
+                                        break;
+                                    case ModelTexture.TextureWrapMode.Repeat:
+                                        _shader.TextureRegionU = KingdomShader.DefaultTextureRegion;
+                                        _shader.TextureWrapModeU = TextureWrapMode.Repeat;
+                                        break;
+                                    case ModelTexture.TextureWrapMode.RegionClamp:
+                                        _shader.TextureRegionU = texture.RegionU;
+                                        _shader.TextureWrapModeU = TextureWrapMode.Clamp;
+                                        break;
+                                    case ModelTexture.TextureWrapMode.RegionRepeat:
+                                        _shader.TextureRegionU = texture.RegionU;
+                                        _shader.TextureWrapModeU = TextureWrapMode.Repeat;
+                                        break;
+                                }
+                                switch (texture.ModelTexture.TextureAddressMode.AddressV)
+                                {
+                                    case ModelTexture.TextureWrapMode.Clamp:
+                                        _shader.TextureRegionV = KingdomShader.DefaultTextureRegion;
+                                        _shader.TextureWrapModeV = TextureWrapMode.Clamp;
+                                        break;
+                                    case ModelTexture.TextureWrapMode.Repeat:
+                                        _shader.TextureRegionV = KingdomShader.DefaultTextureRegion;
+                                        _shader.TextureWrapModeV = TextureWrapMode.Repeat;
+                                        break;
+                                    case ModelTexture.TextureWrapMode.RegionClamp:
+                                        _shader.TextureRegionV = texture.RegionU;
+                                        _shader.TextureWrapModeV = TextureWrapMode.Clamp;
+                                        break;
+                                    case ModelTexture.TextureWrapMode.RegionRepeat:
+                                        _shader.TextureRegionV = texture.RegionU;
+                                        _shader.TextureWrapModeV = TextureWrapMode.Repeat;
+                                        break;
+                                }
+
                                 pass.Apply();
                             }
                         }

--- a/OpenKh.Game/States/MapState.cs
+++ b/OpenKh.Game/States/MapState.cs
@@ -4,6 +4,7 @@ using OpenKh.Engine.Parsers;
 using OpenKh.Game.Debugging;
 using OpenKh.Game.Infrastructure;
 using OpenKh.Game.Models;
+using OpenKh.Game.Shaders;
 using OpenKh.Kh2;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,7 +18,7 @@ namespace OpenKh.Game.States
         private GraphicsDeviceManager _graphics;
         private InputManager _input;
         private List<Mesh> _models = new List<Mesh>();
-        private BasicEffect _effect;
+        private KingdomShader _shader;
         private Camera _camera;
 
         private int _worldId = 2;
@@ -31,7 +32,7 @@ namespace OpenKh.Game.States
             _archiveManager = initDesc.ArchiveManager;
             _graphics = initDesc.GraphicsDevice;
             _input = initDesc.InputManager;
-            _effect = new BasicEffect(_graphics.GraphicsDevice);
+            _shader = new KingdomShader(initDesc.ContentManager);
             _camera = new Camera()
             {
                 CameraPosition = new Vector3(0, 100, 200),
@@ -70,19 +71,17 @@ namespace OpenKh.Game.States
         {
             _camera.AspectRatio = _graphics.PreferredBackBufferWidth / (float)_graphics.PreferredBackBufferHeight;
 
-            _effect.VertexColorEnabled = true;
-            _effect.Projection = _camera.Projection;
-            _effect.World = _camera.World;
 
-            _effect.GraphicsDevice.RasterizerState = new RasterizerState()
+            _graphics.GraphicsDevice.RasterizerState = new RasterizerState()
             {
                 CullMode = CullMode.CullClockwiseFace
             };
-            _effect.GraphicsDevice.DepthStencilState = new DepthStencilState();
+            _graphics.GraphicsDevice.DepthStencilState = new DepthStencilState();
 
-
-            foreach (var pass in _effect.CurrentTechnique.Passes)
+            _shader.Pass(pass =>
             {
+                _shader.ProjectionView = _camera.Projection;
+                _shader.WorldView = _camera.World;
                 pass.Apply();
 
                 foreach (var mesh in _models)
@@ -97,10 +96,9 @@ namespace OpenKh.Game.States
                         if (textureIndex < mesh.Textures.Length)
                         {
                             var texture = mesh.Textures[textureIndex];
-                            if (_effect.Texture != texture)
+                            if (_shader.Texture0 != texture)
                             {
-                                _effect.Texture = texture;
-                                _effect.TextureEnabled = _effect.Texture != null;
+                                _shader.Texture0 = texture;
                                 pass.Apply();
                             }
                         }

--- a/OpenKh.Game/States/MapState.cs
+++ b/OpenKh.Game/States/MapState.cs
@@ -129,11 +129,11 @@ namespace OpenKh.Game.States
                                         _shader.TextureWrapModeV = TextureWrapMode.Repeat;
                                         break;
                                     case ModelTexture.TextureWrapMode.RegionClamp:
-                                        _shader.TextureRegionV = texture.RegionU;
+                                        _shader.TextureRegionV = texture.RegionV;
                                         _shader.TextureWrapModeV = TextureWrapMode.Clamp;
                                         break;
                                     case ModelTexture.TextureWrapMode.RegionRepeat:
-                                        _shader.TextureRegionV = texture.RegionU;
+                                        _shader.TextureRegionV = texture.RegionV;
                                         _shader.TextureWrapModeV = TextureWrapMode.Repeat;
                                         break;
                                 }

--- a/OpenKh.Game/States/MapState.cs
+++ b/OpenKh.Game/States/MapState.cs
@@ -96,9 +96,10 @@ namespace OpenKh.Game.States
                         if (textureIndex < mesh.Textures.Length)
                         {
                             var texture = mesh.Textures[textureIndex];
-                            if (_shader.Texture0 != texture)
+                            if (_shader.Texture0 != texture.Texture2D)
                             {
-                                _shader.Texture0 = texture;
+                                _shader.Texture0 = texture.Texture2D;
+                                _shader.TextureRegion = texture.Region;
                                 pass.Apply();
                             }
                         }
@@ -115,14 +116,15 @@ namespace OpenKh.Game.States
                         index = (index + 1) % mesh.Segments.Length;
                     }
                 }
-            }
+            });
         }
 
         private void BasicallyForceToReloadEverything()
         {
             _models.Clear();
             LoadMap(_worldId, _placeId);
-            LoadObjEntry(_objEntryId);
+            //LoadObjEntry("F_LM670_MATSU");
+            LoadObjEntry("P_EX100");
         }
 
         private void LoadObjEntry(string name)
@@ -209,7 +211,7 @@ namespace OpenKh.Game.States
                     SegmentId = part.SegmentIndex,
                     TextureId = part.TextureIndex
                 }).ToArray(),
-                Textures = textures?.Images?.Select(texture => texture.CreateTexture(graphics)).ToArray() ?? new Texture2D[0]
+                Textures = textures?.Images?.Select(texture => new KingdomTexture(texture, graphics)).ToArray() ?? new KingdomTexture[0]
             };
         }
 

--- a/OpenKh.Kh2/ModelTexture.cs
+++ b/OpenKh.Kh2/ModelTexture.cs
@@ -28,7 +28,6 @@ namespace OpenKh.Kh2
         {
             private readonly byte[] _data;
             private readonly byte[] _palette;
-            private readonly TextureAddressMode _textureAddressMode;
             private readonly int _csp;
             private readonly int _csa;
 
@@ -41,7 +40,7 @@ namespace OpenKh.Kh2
                 PixelFormat = pixelFormat;
                 _data = data;
                 _palette = palette;
-                _textureAddressMode = textureAddressMode;
+                TextureAddressMode = textureAddressMode;
                 _csp = csp;
                 _csa = csa;
             }
@@ -49,6 +48,8 @@ namespace OpenKh.Kh2
             public Size Size { get; }
 
             public PixelFormat PixelFormat { get; }
+
+            public TextureAddressMode TextureAddressMode { get; }
 
             public byte[] GetClut()
             {
@@ -173,16 +174,21 @@ namespace OpenKh.Kh2
 
         private class _TextureAddressMode
         {
+            private const int MinU = 4;
+            private const int MaxU = 14;
+            private const int MinV = 24;
+            private const int MaxV = 34;
+
             [Data] public long Data { get; set; }
             public TextureWrapMode AddressU { get => (TextureWrapMode)GetBits(Data, 0, 2); set => Data = SetBits(Data, 0, 2, (int)value); }
             public TextureWrapMode AddressV { get => (TextureWrapMode)GetBits(Data, 2, 2); set => Data = SetBits(Data, 2, 2, (int)value); }
-            public int Left { get => GetBits(Data, 4, 10); set => Data = SetBits(Data, 4, 10, value); }
-            public int Top { get => GetBits(Data, 14, 10); set => Data = SetBits(Data, 14, 10, value); }
-            public int Right { get => GetBits(Data, 24, 10); set => Data = SetBits(Data, 24, 10, value); }
-            public int Bottom { get => GetBits(Data, 34, 10); set => Data = SetBits(Data, 34, 10, value); }
+            public int Left { get => GetBits(Data, MinU, 10); set => Data = SetBits(Data, MinU, 10, value); }
+            public int Top { get => GetBits(Data, MinV, 10); set => Data = SetBits(Data, MinV, 10, value); }
+            public int Right { get => GetBits(Data, MaxU, 10); set => Data = SetBits(Data, MaxU, 10, value); }
+            public int Bottom { get => GetBits(Data, MaxV, 10); set => Data = SetBits(Data, MaxV, 10, value); }
         }
 
-        internal class TextureAddressMode
+        public class TextureAddressMode
         {
             public TextureWrapMode AddressU { get; set; }
             public TextureWrapMode AddressV { get; set; }


### PR DESCRIPTION
This fixes some of the odd texture rendering glitches caused by the inability of emulating the "Texture Wrap Mode" as PlayStation 2 internally does.

BEFORE
![before](https://user-images.githubusercontent.com/6128729/82959585-fbc05300-9faf-11ea-9b78-bd01c4323d97.png)

AFTER
![after](https://user-images.githubusercontent.com/6128729/82959600-04188e00-9fb0-11ea-9e51-ecfc255c1367.png)
