### PR TITLE
Fixes countless bugs that risked to damage files changed from #107

### DIFF
--- a/OpenKh.Command.MsgTool/Program.cs
+++ b/OpenKh.Command.MsgTool/Program.cs
@@ -45,7 +45,7 @@ namespace OpenKh.Command.MsgTool
                 var barEntries = Bar.Read(stream);
                 foreach (Bar.Entry barEntry in barEntries)
                 {
-                    if (barEntry.Type == Bar.EntryType.Binary)
+                    if (barEntry.Type == Bar.EntryType.List)
                     {
                         barEntry.Stream.Position = 0;
                         ConvertMsgToXml(barEntry.Stream, outputFileName);

--- a/OpenKh.Kh2/Contextes/FontContext.cs
+++ b/OpenKh.Kh2/Contextes/FontContext.cs
@@ -45,7 +45,7 @@ namespace OpenKh.Kh2.Contextes
                         ReadIcon(entry, ref imageIcon, ref spacingIcon, 256, 160);
                         break;
                     case "ftst":
-                        if (entry.Type == Bar.EntryType.Binary)
+                        if (entry.Type == Bar.EntryType.List)
                             palette = Ftst.Read(entry.Stream).ToDictionary(x => x.Id, x => x);
                         break;
                 }
@@ -56,7 +56,7 @@ namespace OpenKh.Kh2.Contextes
         {
             switch (entry.Type)
             {
-                case Bar.EntryType.Binary:
+                case Bar.EntryType.List:
                     spacing = ReadSpacing(entry);
                     break;
                 case Bar.EntryType.RawBitmap:
@@ -72,7 +72,7 @@ namespace OpenKh.Kh2.Contextes
         {
             switch (entry.Type)
             {
-                case Bar.EntryType.Binary:
+                case Bar.EntryType.List:
                     spacing = ReadSpacing(entry);
                     break;
                 case Bar.EntryType.RawBitmap:

--- a/OpenKh.Tools.Common/Kh2Utilities.cs
+++ b/OpenKh.Tools.Common/Kh2Utilities.cs
@@ -65,7 +65,7 @@ namespace OpenKh.Tools.Common
 
             var entries = Bar.Read(stream);
             var entry = entries
-                .FirstOrDefault(x => x.Type == Bar.EntryType.Binary && x.Name == "sys");
+                .FirstOrDefault(x => x.Type == Bar.EntryType.List && x.Name == "sys");
 
             if (entry == null)
                 throw new InvalidFileException<Msg>();

--- a/OpenKh.Tools.Kh2SystemEditor/Extensions/BarExtensions.cs
+++ b/OpenKh.Tools.Kh2SystemEditor/Extensions/BarExtensions.cs
@@ -10,6 +10,6 @@ namespace OpenKh.Tools.Kh2SystemEditor.Extensions
     {
         public static Stream GetBinaryStream(this IEnumerable<Bar.Entry> entries, string name) =>
             // TODO throws exception if that entry is not found
-            entries.First(x => x.Name == name && x.Index == 0 && x.Type == Bar.EntryType.Binary).Stream.SetPosition(0);
+            entries.First(x => x.Name == name && x.Index == 0 && x.Type == Bar.EntryType.List).Stream.SetPosition(0);
     }
 }

--- a/OpenKh.Tools.Kh2SystemEditor/ViewModels/SystemEditorViewModel.cs
+++ b/OpenKh.Tools.Kh2SystemEditor/ViewModels/SystemEditorViewModel.cs
@@ -180,7 +180,7 @@ namespace OpenKh.Tools.Kh2SystemEditor.ViewModels
         }
 
         private IEnumerable<Bar.Entry> SaveSystemEntry(IEnumerable<Bar.Entry> entries, ISystemGetChanges battleGetChanges) =>
-            entries.ForEntry(Bar.EntryType.Binary, battleGetChanges.EntryName, 0, entry => entry.Stream = battleGetChanges.CreateStream());
+            entries.ForEntry(Bar.EntryType.List, battleGetChanges.EntryName, 0, entry => entry.Stream = battleGetChanges.CreateStream());
 
 
         private T GetDefaultViewModelInstance<T>()

--- a/OpenKh.Tools.Kh2TextEditor/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.Kh2TextEditor/ViewModels/MainViewModel.cs
@@ -392,7 +392,7 @@ namespace OpenKh.Tools.Kh2TextEditor.ViewModels
                 return false;
 
             var msgEntry = Bar.Read(stream)
-                .FirstOrDefault(x => x.Type == Bar.EntryType.Binary);
+                .FirstOrDefault(x => x.Type == Bar.EntryType.List);
 
             if (msgEntry == null)
                 return false;
@@ -413,7 +413,7 @@ namespace OpenKh.Tools.Kh2TextEditor.ViewModels
         private void WriteBar(List<Bar.Entry> entries, Stream stream)
         {
             var newEntries = entries
-                .ForEntry(Bar.EntryType.Binary, _barEntryName, 0, entry => WriteMsg(entry.Stream));
+                .ForEntry(Bar.EntryType.List, _barEntryName, 0, entry => WriteMsg(entry.Stream));
 
             Bar.Write(stream, newEntries);
         }

--- a/OpenKh.Tools.LevelUpEditor/ViewModels/LvupViewModel.cs
+++ b/OpenKh.Tools.LevelUpEditor/ViewModels/LvupViewModel.cs
@@ -86,7 +86,7 @@ namespace OpenKh.Tools.LevelUpEditor.ViewModels
                 using (var file = File.Open(fileName, FileMode.Open))
                 {
                     var ent = Bar.Read(file,
-                        (str, type) => str == "lvup" && type == Bar.EntryType.Binary)
+                        (str, type) => str == "lvup" && type == Bar.EntryType.List)
                         .FirstOrDefault();
 
                     if (ent != null)


### PR DESCRIPTION
The Pull Request #107 renamed `EntryType.Binary` to `EntryType.List` and added a `EntryType.Binary` for a different kind of value. 
But most of the tools did not picked up the change and are still using the `EntryType.Binary`  rather than `EntryType.List`. This change breaks tools and game engine and the pull request aims to fix it.