### PR TITLE
Fixing A XML serialization problem on OpenKh.Command.MsgTool.

### DIFF
--- a/OpenKh.Kh2/Messages/MsgSerializer.cs
+++ b/OpenKh.Kh2/Messages/MsgSerializer.cs
@@ -187,7 +187,7 @@ namespace OpenKh.Kh2.Messages
             },
             new SerializerModel
             {
-                Name = "delay&fade",
+                Name = "delayandfade",
                 Command = MessageCommand.DelayAndFade,
                 Serializer = x => ToDelayAndFade(x.Data),
                 Deserializer = x => FromDelayAndFade(x)

--- a/OpenKh.Tests/kh2/MsgSerializerTests.cs
+++ b/OpenKh.Tests/kh2/MsgSerializerTests.cs
@@ -220,8 +220,8 @@ namespace OpenKh.Tests.kh2
         }
 
         [Theory]
-        [InlineData(new byte[] { 0x17, 0x0c, 0xdd }, "{:delay&fade 0C DD}")]
-        [InlineData(new byte[] { 0x17, 0x01, 0x02 }, "{:delay&fade 01 02}")]
+        [InlineData(new byte[] { 0x17, 0x0c, 0xdd }, "{:delayandfade 0C DD}")]
+        [InlineData(new byte[] { 0x17, 0x01, 0x02 }, "{:delayandfade 01 02}")]
         public void SerializeDelayAndFade(byte[] data, string expected)
         {
             var commands = Encoders.InternationalSystem.Decode(data);
@@ -230,8 +230,8 @@ namespace OpenKh.Tests.kh2
         }
 
         [Theory]
-        [InlineData("{:delay&fade 0C DD}", new byte[] { 0x17, 0x0c, 0xdd, 0x00 })]
-        [InlineData("{:delay&fade 01 02}", new byte[] { 0x17, 0x01, 0x02, 0x00 })]
+        [InlineData("{:delayandfade 0C DD}", new byte[] { 0x17, 0x0c, 0xdd, 0x00 })]
+        [InlineData("{:delayandfade 01 02}", new byte[] { 0x17, 0x01, 0x02, 0x00 })]
         public void DeserializeDelayAndFade(string text, byte[] expected)
         {
             var commands = MsgSerializer.DeserializeText(text);


### PR DESCRIPTION
```
OpenKh.Command.MsgTool.exe -i H:\KH2fm.yaz0r\msg\jp\bb.bar
```

This will create `"H:\KH2fm.yaz0r\msg\jp\al.xml"`

```xml
<?xml version="1.0" encoding="utf-8"?>
<messages>
  <message id="11">
    <text>１０１ÙÖ–?jü02</text>
    <text>Ù??▲o0j、b—ß7uh</text>
  </message>
  <message id="12">
    <text>１０２ÙÖ–?lc7èâá</text>
  </message>
  <message id="13">
    <text>１０３426Ò2s16f1ÙÖ–?</text>
    <text>Ù??▲o0j、426Ò2u3s</text>
  </message>
  <message id="14">
    <text>１０４??´</text>
    <unk value="FF" />
    <text>?jpkc</text>
    <text>Ù??▲o0j、??–?lyºá</text>
  </message>
  ...
</messages>
```

Currently Japanese decoder isn't shipped so please someone check this please! (by using English version or etc...)