### PR TITLE
Fix aspect ratio for ReMIX build

### DIFF
--- a/OpenKh.Game/Debugging/DebugOverlay.cs
+++ b/OpenKh.Game/Debugging/DebugOverlay.cs
@@ -44,7 +44,14 @@ namespace OpenKh.Game.Debugging
             _graphics = initDesc.GraphicsDevice;
 
             _drawing = new MonoDrawing(_graphics.GraphicsDevice, initDesc.ContentManager);
-            
+            var viewport = initDesc.GraphicsDevice.GraphicsDevice.Viewport;
+            _drawing.SetProjection(
+                viewport.Width,
+                viewport.Height,
+                Global.ResolutionWidth,
+                Global.ResolutionHeight,
+                1.0f);
+
             var messageContext = _kernel.SystemMessageContext;
             _encoder = messageContext.Encoder;
             _messageRenderer = new Kh2MessageRenderer(_drawing, messageContext);

--- a/OpenKh.Game/Global.cs
+++ b/OpenKh.Game/Global.cs
@@ -1,0 +1,12 @@
+﻿namespace OpenKh.Game
+{
+    public class Global
+    {
+        public const int ResolutionWidth = 512;
+        public const int ResolutionHeight = 416;
+        public const int ResolutionRemixWidth = 684;
+        public const float ResolutionReMixRatio = 0.925f;
+
+        public const float ResolutionBoostRatio = 2;
+    }
+}

--- a/OpenKh.Game/MonoDrawing.cs
+++ b/OpenKh.Game/MonoDrawing.cs
@@ -73,17 +73,7 @@ namespace OpenKh.Game
         private readonly MyVertex[] _vertices;
         private Texture2D _texture;
         private int _currentSpriteIndex;
-
-        public xnaf.Matrix ProjectionView
-        {
-            get => _shader.ProjectionView;
-            set => _shader.ProjectionView = value;
-        }
-        public Texture2D Texture0
-        {
-            get => _shader.Texture0;
-            set => _shader.Texture0 = value;
-        }
+        private xnaf.Matrix _projectionView = xnaf.Matrix.Identity;
 
         public MonoDrawing(GraphicsDevice graphicsDevice, ContentManager contentManager)
         {
@@ -113,6 +103,17 @@ namespace OpenKh.Game
             _indexBuffer = CreateIndexBufferForSprites(graphicsDevice, MaxSpriteCountPerDraw);
             _vertices = new MyVertex[MaxSpriteCountPerDraw * 4];
             _currentSpriteIndex = 0;
+        }
+
+        public void SetProjection(float width, float height, float internalWidth, float internalHeight, float ratio)
+        {
+            var heightRatio = internalHeight / height;
+            width *= heightRatio;
+            height *= heightRatio;
+            width *= ratio;
+
+            var left = (internalWidth - width) / 2;
+            _projectionView = xnaf.Matrix.CreateOrthographicOffCenter(left, width + left, height, 0, -1000.0f, +1000.0f);
         }
 
         public GraphicsDevice GraphicsDevice { get; }
@@ -202,8 +203,8 @@ namespace OpenKh.Game
             _vertexBuffer.SetData(_vertices);
             _shader.Pass(pass =>
             {
-                Texture0 = _texture;
-                ProjectionView = xnaf.Matrix.CreateOrthographicOffCenter(0, 512, 416, 0, -1000.0f, +1000.0f);
+                _shader.Texture0 = _texture;
+                _shader.ProjectionView = _projectionView;
                 _shader.WorldView = xnaf.Matrix.Identity;
                 _shader.TextureRegionU = KingdomShader.DefaultTextureRegion;
                 _shader.TextureRegionV = KingdomShader.DefaultTextureRegion;

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -1,9 +1,10 @@
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using OpenKh.Common;
 using OpenKh.Game.DataContent;
 using OpenKh.Game.Debugging;
 using OpenKh.Game.Infrastructure;
 using OpenKh.Game.States;
+using System;
 using System.IO;
 
 namespace OpenKh.Game
@@ -45,19 +46,23 @@ namespace OpenKh.Game
 
         public OpenKhGame()
         {
+            _dataContent = new SafeDataContent(CreateDataContent(".", "KH2.IDX", "KH2.IMG"));
+            _kernel = new Kernel(_dataContent);
+
+            var resolutionWidth = _kernel.IsReMix ?
+                Global.ResolutionRemixWidth :
+                Global.ResolutionWidth;
+
             graphics = new GraphicsDeviceManager(this)
             {
-                PreferredBackBufferWidth = 512,
-                PreferredBackBufferHeight = 416
+                PreferredBackBufferWidth = (int)Math.Round(resolutionWidth * Global.ResolutionBoostRatio),
+                PreferredBackBufferHeight = (int)Math.Round(Global.ResolutionHeight * Global.ResolutionBoostRatio)
             };
 
             Content.RootDirectory = "Content";
             IsMouseVisible = true;
 
-            _dataContent = new SafeDataContent(CreateDataContent(".", "KH2.IDX", "KH2.IMG"));
-
             archiveManager = new ArchiveManager(_dataContent);
-            _kernel = new Kernel(_dataContent);
             inputManager = new InputManager();
             _debugOverlay = new DebugOverlay(this);
         }

--- a/OpenKh.Game/States/TitleState.cs
+++ b/OpenKh.Game/States/TitleState.cs
@@ -142,6 +142,14 @@ namespace OpenKh.Game.States
             _stateChange = initDesc.StateChange;
 
             drawing = new MonoDrawing(initDesc.GraphicsDevice.GraphicsDevice, initDesc.ContentManager);
+            var viewport = initDesc.GraphicsDevice.GraphicsDevice.Viewport;
+            drawing.SetProjection(
+                viewport.Width,
+                viewport.Height,
+                Global.ResolutionWidth,
+                Global.ResolutionHeight,
+                1.0f);
+
             cachedSurfaces = new Dictionary<string, IEnumerable<ISurface>>();
 
             if (_kernel.IsReMix)


### PR DESCRIPTION
This pull request adjusts the aspect ration based on which game build is loaded. PS2, PS3 and PS4 files will work, although for ReMIX the HD Asset content needs to be stripped.

This is how it looks using PS2 files:
![image](https://user-images.githubusercontent.com/6128729/83327322-8e901480-a272-11ea-821a-7b729c1ee9e7.png)

This is how it looks using ReMIX files:
![image](https://user-images.githubusercontent.com/6128729/83327350-e9297080-a272-11ea-8e9f-2f2796b7fade.png)

The text is not positioned on the far top-left when the wide-screen mode is used, but I am not concerned since it is only visible for debugging purposes.

Also I zoomed out the output by 2x in `Global.ResolutionBoostRatio`. Right now I would just keep it there. But in the future I propose to have some kind of configuration file to give flexibility to who does not have the source code to modify resolution boost and other stuff.
