### PR TITLE
HD Asset detection

### DIFF
--- a/OpenKh.Common/Archives/HdAsset.cs
+++ b/OpenKh.Common/Archives/HdAsset.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -131,5 +131,33 @@ namespace OpenKh.Common.Archives
         }
 
         public static HdAsset Read(Stream stream) => new HdAsset(stream);
+
+        public static bool IsValid(Stream stream)
+        {
+            const int MinimumPossibleSizeForHeader = 0x10;
+            const int EstimatedMaximumPossibleSizeForOriginalAsset = 32 * 1024 * 1024;
+            const int EstimatedMaximumPossibleRemasteredAssetCount = 1024;
+
+            if (stream.Length < MinimumPossibleSizeForHeader)
+                return false;
+
+            var originalAssetLength = stream.ReadInt32();
+            if (originalAssetLength > EstimatedMaximumPossibleSizeForOriginalAsset)
+                return false;
+
+            var assetCount = stream.ReadInt32();
+            if (assetCount >= EstimatedMaximumPossibleRemasteredAssetCount)
+                return false;
+
+            if (stream.ReadInt32() != 0)
+                return false;
+            if (stream.ReadInt32() != 0)
+                return false;
+
+            if (originalAssetLength + MinimumPossibleSizeForHeader > stream.Length)
+                return false;
+
+            return true;
+        }
     }
 }

--- a/OpenKh.Common/Archives/HdAsset.cs
+++ b/OpenKh.Common/Archives/HdAsset.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -68,8 +68,9 @@ namespace OpenKh.Common.Archives
             set => entries = value ?? throw new ArgumentNullException(nameof(Entries));
         }
 
-        private HdAsset()
+        public HdAsset()
         {
+            _header = new Header();
             Stream = new MemoryStream();
             Entries = new List<Entry>();
         }
@@ -129,7 +130,6 @@ namespace OpenKh.Common.Archives
             return outStream;
         }
 
-        public static HdAsset New() => new HdAsset();
         public static HdAsset Read(Stream stream) => new HdAsset(stream);
     }
 }

--- a/OpenKh.Game/DataContent/HdAssetContent.cs
+++ b/OpenKh.Game/DataContent/HdAssetContent.cs
@@ -1,0 +1,27 @@
+﻿using OpenKh.Common.Archives;
+using OpenKh.Game.Infrastructure;
+using System.IO;
+
+namespace OpenKh.Game.DataContent
+{
+    public class HdAssetContent : IDataContent
+    {
+        private readonly IDataContent _innerDataContext;
+
+        public HdAssetContent(IDataContent innerDataContext)
+        {
+            _innerDataContext = innerDataContext;
+        }
+
+        public bool FileExists(string fileName) => _innerDataContext.FileExists(fileName);
+
+        public Stream FileOpen(string fileName)
+        {
+            var stream = _innerDataContext.FileOpen(fileName);
+            if (stream == null)
+                return null;
+
+            return HdAsset.Read(stream).Stream;
+        }
+    }
+}

--- a/OpenKh.Game/Infrastructure/Kernel.cs
+++ b/OpenKh.Game/Infrastructure/Kernel.cs
@@ -134,8 +134,12 @@ namespace OpenKh.Game.Infrastructure
         public static bool IsReMixFileHasHdAssetHeader(IDataContent dataContent, string region)
         {
             var testFileName = $"menu/{region}/titlejf.2ld";
-            using var stream = dataContent.FileOpen(testFileName);
-            return HdAsset.IsValid(stream);
+            var stream = dataContent.FileOpen(testFileName);
+            if (stream == null)
+                return false;
+
+            using (stream)
+                return HdAsset.IsValid(stream);
         }
     }
 }

--- a/OpenKh.Game/Infrastructure/Kernel.cs
+++ b/OpenKh.Game/Infrastructure/Kernel.cs
@@ -1,4 +1,5 @@
 ﻿using OpenKh.Common;
+using OpenKh.Common.Archives;
 using OpenKh.Engine;
 using OpenKh.Engine.Extensions;
 using OpenKh.Engine.Renders;
@@ -40,7 +41,7 @@ namespace OpenKh.Game.Infrastructure
             FontContext = new FontContext();
             MessageProvider = new Kh2MessageProvider();
             RegionId = DetectRegion(dataContent);
-            IsReMix = DetectReMix(dataContent, Region);
+            IsReMix = IsReMixFileExists(dataContent, Region);
 
             // Load files in the same order as KH2 does
             ObjEntries = LoadFile("00objentry.bin", stream => Objentry.Read(stream));
@@ -124,10 +125,17 @@ namespace OpenKh.Game.Infrastructure
             throw new Exception("Unable to detect any region for the game. Some files are potentially missing.");
         }
 
-        private static bool DetectReMix(IDataContent dataContent, string region)
+        public static bool IsReMixFileExists(IDataContent dataContent, string region)
         {
             var testFileName = $"menu/{region}/titlejf.2ld";
             return dataContent.FileExists(testFileName);
+        }
+
+        public static bool IsReMixFileHasHdAssetHeader(IDataContent dataContent, string region)
+        {
+            var testFileName = $"menu/{region}/titlejf.2ld";
+            using var stream = dataContent.FileOpen(testFileName);
+            return HdAsset.IsValid(stream);
         }
     }
 }

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -6,6 +6,7 @@ using OpenKh.Game.Infrastructure;
 using OpenKh.Game.States;
 using System;
 using System.IO;
+using System.Runtime.Serialization;
 
 namespace OpenKh.Game
 {
@@ -46,7 +47,11 @@ namespace OpenKh.Game
 
         public OpenKhGame()
         {
-            _dataContent = new SafeDataContent(CreateDataContent(".", "KH2.IDX", "KH2.IMG"));
+            _dataContent = CreateDataContent(".", "KH2.IDX", "KH2.IMG");
+            if (Kernel.IsReMixFileExists(_dataContent, "fm") && Kernel.IsReMixFileHasHdAssetHeader(_dataContent, "fm"))
+                _dataContent = new HdAssetContent(_dataContent);
+            _dataContent = new SafeDataContent(_dataContent);
+
             _kernel = new Kernel(_dataContent);
 
             var resolutionWidth = _kernel.IsReMix ?

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -6,7 +6,6 @@ using OpenKh.Game.Infrastructure;
 using OpenKh.Game.States;
 using System;
 using System.IO;
-using System.Runtime.Serialization;
 
 namespace OpenKh.Game
 {
@@ -48,7 +47,7 @@ namespace OpenKh.Game
         public OpenKhGame()
         {
             _dataContent = CreateDataContent(".", "KH2.IDX", "KH2.IMG");
-            if (Kernel.IsReMixFileExists(_dataContent, "fm") && Kernel.IsReMixFileHasHdAssetHeader(_dataContent, "fm"))
+            if (Kernel.IsReMixFileHasHdAssetHeader(_dataContent, "fm"))
                 _dataContent = new HdAssetContent(_dataContent);
             _dataContent = new SafeDataContent(_dataContent);
 


### PR DESCRIPTION
This fixes the issue #124, where it was not possible to load PS4 remastered assets without stripping out the HD content.

#124 suggests to prompt the user to strip the HD stuff, which implies that the game files would be modified. This pull request takes a step further and just let the game engine to work without modifying them. The performance impact of this pull request is that now the game uses more ram for PS4 files, since all the HD textures will be loaded in memory as well.

When the HdAsset support for PS3 will be implemented, there will be potentially no changes to the game engine to make it working for PS3 too.

Finally, there are minor API changes:
* `HdAsset.New()` has been deleted, since it would make more sense to just invoke `new HdAsset()`
* Adds `HdAsset.IsValid`, which tries to detect if a PS4 ReMIX HD asset file is valid.