### PR TITLE
Fix automated builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
     vsVersion: 'latest'
-    msbuildArgs: '/t:Build /p:DebugType=None /p:DebugSymbols=false /p:OutputPath=$(Build.ArtifactStagingDirectory)'
+    msbuildArgs: '/t:Build /p:DebugType=None /p:DebugSymbols=false /p:OutputPath=$(Build.ArtifactStagingDirectory)/openkh'
     maximumCpuCount: true
 
 - task: VSBuild@1
@@ -69,7 +69,7 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
     vsVersion: 'latest'
-    msbuildArgs: '/t:Build /p:DebugType=None /p:DebugSymbols=false /p:OutputPath=$(Build.ArtifactStagingDirectory)'
+    msbuildArgs: '/t:Build /p:DebugType=None /p:DebugSymbols=false /p:OutputPath=$(Build.ArtifactStagingDirectory)/openkh'
     maximumCpuCount: true
 
 - task: VSBuild@1
@@ -79,7 +79,7 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
     vsVersion: 'latest'
-    msbuildArgs: '/t:Build /p:DebugType=None /p:DebugSymbols=false /p:OutputPath=$(Build.ArtifactStagingDirectory)'
+    msbuildArgs: '/t:Build /p:DebugType=None /p:DebugSymbols=false /p:OutputPath=$(Build.ArtifactStagingDirectory)/openkh'
     maximumCpuCount: true
 
 - task: PublishBuildArtifacts@1

--- a/build.ps1
+++ b/build.ps1
@@ -21,6 +21,7 @@ $solution = "${solutionBase}.sln"
 
 function Test-Success([int] $exitCode) {
     if ($exitCode -ne 0) {
+        Remove-Item $solution -ErrorAction Ignore
         Write-Error "Last command returned error $exitCode, therefore the build is canceled."
         exit
     }
@@ -29,6 +30,9 @@ function Test-Success([int] $exitCode) {
 # Use submodules
 git submodule update --init --recursive --depth 1
 Test-Success $LASTEXITCODE
+
+# Remove previously created solution file
+Remove-Item $solution -ErrorAction Ignore
 
 # Restore NuGet packages
 dotnet restore
@@ -58,3 +62,6 @@ Get-ChildItem -Filter OpenKh.Game* | ForEach-Object {
 
 # Publish solution
 dotnet publish $solution --configuration $configuration --verbosity $verbosity --framework netcoreapp3.1 --output $output /p:DebugType=None /p:DebugSymbols=false
+
+# Remove the temporary solution after the solution is published
+Remove-Item $solution -ErrorAction Ignore


### PR DESCRIPTION
Fixes the following two problems:

* The script `build.ps1` fails if you run it on Windows twice. Reason is because the file `OpenKh.Windows.sln` is created but never deleted or replaced.

* Previously we reached a point where OpenKH binaries were stored in a folder called `openkh` inside the zip you can download in GitHub Release. That was very useful on Linux, since the simple command `unzip openkh-xxx.zip` would just un-zip it to its directory. But with the recent releases, if you extract the content of the zip file, everything will be extracted in the directory you're in. And this is not ideal. Also it is useful on Windows too, where you can just right-click and do "extract here".