### PR TITLE
Use Shift-JIS in .NET Core

### DIFF
--- a/OpenKh.Tools.Kh2PlaceEditor/OpenKh.Tools.Kh2PlaceEditor.csproj
+++ b/OpenKh.Tools.Kh2PlaceEditor/OpenKh.Tools.Kh2PlaceEditor.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\OpenKh.Common\OpenKh.Common.csproj" />
     <ProjectReference Include="..\OpenKh.Kh2\OpenKh.Kh2.csproj" />
     <ProjectReference Include="..\OpenKh.Tools.Common\OpenKh.Tools.Common.csproj" />

--- a/OpenKh.Tools.Kh2PlaceEditor/ViewModels/PlaceViewModel.cs
+++ b/OpenKh.Tools.Kh2PlaceEditor/ViewModels/PlaceViewModel.cs
@@ -13,6 +13,11 @@ namespace OpenKh.Tools.Kh2PlaceEditor.ViewModels
         private readonly IMessageProvider _messageProvider;
         private readonly int _index;
 
+        static PlaceViewModel()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
         public PlaceViewModel(IMessageProvider messageProvider,
             string world, int index, Place place)
         {


### PR DESCRIPTION
Fixes the following error when using Kh2PlaceEditor

![image](https://user-images.githubusercontent.com/6128729/83910636-cdd2cf80-a762-11ea-8e77-3f849ab1565b.png)
