### PR TITLE
Fix texture serration glitch

### DIFF
--- a/OpenKh.Engine/Parsers/NewModelParser.cs
+++ b/OpenKh.Engine/Parsers/NewModelParser.cs
@@ -84,7 +84,7 @@ namespace OpenKh.Engine.Parsers
                             (Math.Min(byte.MaxValue, colorA * 2) << 24);
 
                         Vertices.Add(new CustomVertex.PositionColoredTextured(
-                            position, color, vertexIndex.U / 4096.0f, vertexIndex.V / 4096.0f));
+                            position, color, (short)(ushort)vertexIndex.U / 4096.0f, (short)(ushort)vertexIndex.V / 4096.0f));
 
                         indexBuffer[(recenti++) & 3] = baseVertexIndex + i;
                         switch (vertexIndex.Function)


### PR DESCRIPTION
Fixes a rendering glitch where the UV coordinates were not set in the right way.

![Glitch solved](https://user-images.githubusercontent.com/6128729/83919675-05497800-a773-11ea-8c00-978a2ca74a87.jpg)

PLEASE NOTE that in order to completely fix this glitch, [this patch](https://github.com/Xeeynamo/OpenKh/pull/133/files#diff-1b5378629a9e30fab7803dbbd7bfb72eR44) from #133 must be applied first, or instead of the "serration" you would just see black textures.