### PR TITLE
Less flicker on DrawPanel rendering.

### DIFF
--- a/OpenKh.Tools.Common/Controls/DrawPanel.cs
+++ b/OpenKh.Tools.Common/Controls/DrawPanel.cs
@@ -139,6 +139,11 @@ namespace OpenKh.Tools.Common.Controls
             }
         }
 
+        protected override void OnRender(DrawingContext dc)
+        {
+            Present(dc, _writeableBitmap);
+        }
+
         /// <summary>
         /// Rendering on demand.
         /// </summary>
@@ -241,10 +246,7 @@ namespace OpenKh.Tools.Common.Controls
                 BlitSutface(surface);
             }
 
-            using (var dc = _visual.RenderOpen())
-            {
-                Present(dc, _writeableBitmap);
-            }
+            InvalidateVisual(); // call Present() from OnRender
         }
 
         private void BlitSutface(ISpriteTexture surface)


### PR DESCRIPTION
I noticed that `OpenKh.Tools.LayoutViewer` was great editor. Thus I wanted to play layout/sequence with less flicker.

![less-flicker](https://user-images.githubusercontent.com/5955540/83943601-69823f80-a838-11ea-8f1f-6203a9695470.gif)

This pull request is a small patch to improve it a bit.