### PR TITLE
Try to load plugin from `.dll` instead of `.exe`

### DIFF
--- a/OpenKh.Tools.BarEditor/Services/ToolsLoaderService.cs
+++ b/OpenKh.Tools.BarEditor/Services/ToolsLoaderService.cs
@@ -32,7 +32,7 @@ namespace OpenKh.Tools.BarEditor.Services
 			}
 
 			var toolModule = Plugins
-				.GetModules<IToolModule<ToolInvokeDesc>>(null, x => x.Contains(name) && Path.GetExtension(x) == ".exe")
+				.GetModules<IToolModule<ToolInvokeDesc>>(null, x => x.Contains(name) && Path.GetExtension(x) == ".dll")
 				.FirstOrDefault();
 
             if (toolModule.Item1 == null || toolModule.Item2 == null)


### PR DESCRIPTION
- Try to load plugin from `.dll` instead of `.exe`
- Xeeynamo/XeEngine.Tools.Public#2 is also needed to succeed initialization of `ImageViewerViewModel._imageFormatService` which throws `TypeInitializationException` (on resolving `OpenKh.Bbs`).