### PR TITLE
Implement key repeats on debugMenu.

### DIFF
--- a/OpenKh.Game/Infrastructure/InputManager.cs
+++ b/OpenKh.Game/Infrastructure/InputManager.cs
@@ -13,8 +13,8 @@ namespace OpenKh.Game.Infrastructure
 
         public bool IsDebug => repeatableKeyboard.IsKeyPressed(Keys.Tab);
         public bool IsShift => repeatableKeyboard.IsKeyPressed(Keys.RightShift);
-        public bool IsDebugRight => repeatableKeyboard.IsKeyPressed(Keys.Right);
-        public bool IsDebugLeft => repeatableKeyboard.IsKeyPressed(Keys.Left);
+        public bool IsDebugRight => keyboard.IsKeyDown(Keys.Right) && !prevKeyboard.IsKeyDown(Keys.Right);
+        public bool IsDebugLeft => keyboard.IsKeyDown(Keys.Left) && !prevKeyboard.IsKeyDown(Keys.Left);
         public bool IsDebugUp => repeatableKeyboard.IsKeyPressed(Keys.Up);
         public bool IsDebugDown => repeatableKeyboard.IsKeyPressed(Keys.Down);
 

--- a/OpenKh.Game/Infrastructure/InputManager.cs
+++ b/OpenKh.Game/Infrastructure/InputManager.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
+using System;
 
 namespace OpenKh.Game.Infrastructure
 {
@@ -8,21 +9,22 @@ namespace OpenKh.Game.Infrastructure
         private GamePadState pad;
         private KeyboardState keyboard;
         private KeyboardState prevKeyboard;
+        private RepeatableKeyboard repeatableKeyboard = new RepeatableKeyboard();
 
-        public bool IsDebug => keyboard.IsKeyDown(Keys.Tab) && !prevKeyboard.IsKeyDown(Keys.Tab);
-        public bool IsShift => keyboard.IsKeyDown(Keys.LeftShift) || keyboard.IsKeyDown(Keys.RightShift);
-        public bool IsDebugRight => keyboard.IsKeyDown(Keys.Right) && !prevKeyboard.IsKeyDown(Keys.Right);
-        public bool IsDebugLeft => keyboard.IsKeyDown(Keys.Left) && !prevKeyboard.IsKeyDown(Keys.Left);
-        public bool IsDebugUp => keyboard.IsKeyDown(Keys.Up) && !prevKeyboard.IsKeyDown(Keys.Up);
-        public bool IsDebugDown => keyboard.IsKeyDown(Keys.Down) && !prevKeyboard.IsKeyDown(Keys.Down);
+        public bool IsDebug => repeatableKeyboard.IsKeyPressed(Keys.Tab);
+        public bool IsShift => repeatableKeyboard.IsKeyPressed(Keys.RightShift);
+        public bool IsDebugRight => repeatableKeyboard.IsKeyPressed(Keys.Right);
+        public bool IsDebugLeft => repeatableKeyboard.IsKeyPressed(Keys.Left);
+        public bool IsDebugUp => repeatableKeyboard.IsKeyPressed(Keys.Up);
+        public bool IsDebugDown => repeatableKeyboard.IsKeyPressed(Keys.Down);
 
         public bool IsExit => pad.Buttons.Back == ButtonState.Pressed || keyboard.IsKeyDown(Keys.Escape);
         public bool IsUp => Up && !prevKeyboard.IsKeyDown(Keys.Up);
         public bool IsDown => Down && !prevKeyboard.IsKeyDown(Keys.Down);
         public bool IsLeft => Left && !prevKeyboard.IsKeyDown(Keys.Left);
         public bool IsRight => Right && !prevKeyboard.IsKeyDown(Keys.Right);
-        public bool IsCircle => keyboard.IsKeyDown(Keys.K) && !prevKeyboard.IsKeyDown(Keys.K);
-        public bool IsCross => keyboard.IsKeyDown(Keys.L) && !prevKeyboard.IsKeyDown(Keys.L);
+        public bool IsCircle => repeatableKeyboard.IsKeyPressed(Keys.K);
+        public bool IsCross => repeatableKeyboard.IsKeyPressed(Keys.L);
 
         public bool Up => keyboard.IsKeyDown(Keys.Up);
         public bool Down => keyboard.IsKeyDown(Keys.Down);
@@ -33,11 +35,17 @@ namespace OpenKh.Game.Infrastructure
         public bool S => keyboard.IsKeyDown(Keys.S);
         public bool W => keyboard.IsKeyDown(Keys.W);
 
-        public void Update()
+        public void Update(GameTime gameTime)
         {
             pad = GamePad.GetState(PlayerIndex.One);
             prevKeyboard = keyboard;
             keyboard = Keyboard.GetState();
+            repeatableKeyboard.UpdateWith(keyboard, gameTime);
+        }
+
+        public void UnblockRepeats()
+        {
+            repeatableKeyboard.UnblockRepeats();
         }
     }
 }

--- a/OpenKh.Game/Infrastructure/InputManager.cs
+++ b/OpenKh.Game/Infrastructure/InputManager.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using System;
+using System.Linq;
 
 namespace OpenKh.Game.Infrastructure
 {
@@ -40,12 +41,26 @@ namespace OpenKh.Game.Infrastructure
             pad = GamePad.GetState(PlayerIndex.One);
             prevKeyboard = keyboard;
             keyboard = Keyboard.GetState();
-            repeatableKeyboard.UpdateWith(keyboard, gameTime);
-        }
 
-        public void UnblockRepeats()
-        {
-            repeatableKeyboard.UnblockRepeats();
+            var pressedKeys = prevKeyboard.GetPressedKeys();
+            var pressingKeys = keyboard.GetPressedKeys();
+
+            foreach (var keyDown in pressingKeys.Except(pressedKeys))
+            {
+                repeatableKeyboard.PressKey(keyDown);
+            }
+
+            foreach (var keyUp in pressedKeys.Except(pressingKeys))
+            {
+                repeatableKeyboard.ReleaseKey(keyUp);
+            }
+
+            var seconds = (float)gameTime.ElapsedGameTime.TotalSeconds;
+
+            foreach (var keepDown in pressedKeys.Intersect(pressingKeys))
+            {
+                repeatableKeyboard.UpdateKey(keepDown, seconds);
+            }
         }
     }
 }

--- a/OpenKh.Game/Infrastructure/InputManager.cs
+++ b/OpenKh.Game/Infrastructure/InputManager.cs
@@ -12,20 +12,20 @@ namespace OpenKh.Game.Infrastructure
         private KeyboardState prevKeyboard;
         private RepeatableKeyboard repeatableKeyboard = new RepeatableKeyboard();
 
-        public bool IsDebug => repeatableKeyboard.IsKeyPressed(Keys.Tab);
-        public bool IsShift => repeatableKeyboard.IsKeyPressed(Keys.RightShift);
-        public bool IsDebugRight => keyboard.IsKeyDown(Keys.Right) && !prevKeyboard.IsKeyDown(Keys.Right);
-        public bool IsDebugLeft => keyboard.IsKeyDown(Keys.Left) && !prevKeyboard.IsKeyDown(Keys.Left);
-        public bool IsDebugUp => repeatableKeyboard.IsKeyPressed(Keys.Up);
-        public bool IsDebugDown => repeatableKeyboard.IsKeyPressed(Keys.Down);
+        public bool IsDebug => repeatableKeyboard.IsKeyRepeat(Keys.Tab);
+        public bool IsShift => repeatableKeyboard.IsKeyRepeat(Keys.RightShift);
+        public bool IsDebugRight => repeatableKeyboard.IsKeyRepeat(Keys.Right);
+        public bool IsDebugLeft => repeatableKeyboard.IsKeyRepeat(Keys.Left);
+        public bool IsDebugUp => repeatableKeyboard.IsKeyRepeat(Keys.Up);
+        public bool IsDebugDown => repeatableKeyboard.IsKeyRepeat(Keys.Down);
 
         public bool IsExit => pad.Buttons.Back == ButtonState.Pressed || keyboard.IsKeyDown(Keys.Escape);
         public bool IsUp => Up && !prevKeyboard.IsKeyDown(Keys.Up);
         public bool IsDown => Down && !prevKeyboard.IsKeyDown(Keys.Down);
         public bool IsLeft => Left && !prevKeyboard.IsKeyDown(Keys.Left);
         public bool IsRight => Right && !prevKeyboard.IsKeyDown(Keys.Right);
-        public bool IsCircle => repeatableKeyboard.IsKeyPressed(Keys.K);
-        public bool IsCross => repeatableKeyboard.IsKeyPressed(Keys.L);
+        public bool IsCircle => repeatableKeyboard.IsKeyRepeat(Keys.K);
+        public bool IsCross => repeatableKeyboard.IsKeyRepeat(Keys.L);
 
         public bool Up => keyboard.IsKeyDown(Keys.Up);
         public bool Down => keyboard.IsKeyDown(Keys.Down);

--- a/OpenKh.Game/Infrastructure/RepeatableKeyboard.cs
+++ b/OpenKh.Game/Infrastructure/RepeatableKeyboard.cs
@@ -1,0 +1,110 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace OpenKh.Game.Infrastructure
+{
+    class RepeatableKeyboard
+    {
+        private bool isPressing = false;
+        private Keys lastPressed;
+        private double nextRepeatInMillis = 0;
+        private int keyboardDelay;
+        private int keyboardSpeed;
+        private bool blockRepeats = false;
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool SystemParametersInfo(int uiAction, int uiParam, out int pvParam, int fWinIni);
+
+        /// <summary>
+        /// Retrieves the keyboard repeat-delay setting, which is a value in the range from 0 (approximately 250 ms delay) through 3 (approximately 1 second delay). The actual delay associated with each value may vary depending on the hardware. The pvParam parameter must point to an integer variable that receives the setting.
+        /// </summary>
+        /// <remarks>
+        /// first:
+        /// 0 = 250 ms
+        /// 1 = 500 ms
+        /// 2 = 750 ms
+        /// 3 = 1000 ms
+        /// </remarks>
+        const int SPI_GETKEYBOARDDELAY = 0x16;
+
+        /// <summary>
+        /// Retrieves the keyboard repeat-speed setting, which is a value in the range from 0 (approximately 2.5 repetitions per second) through 31 (approximately 30 repetitions per second). The actual repeat rates are hardware-dependent and may vary from a linear scale by as much as 20%. The pvParam parameter must point to a DWORD variable that receives the setting.
+        /// </summary>
+        /// <remarks>
+        /// repeat:
+        /// 0 = 400 ms
+        /// ...
+        /// 31 = 33 ms
+        /// </remarks>
+        const int SPI_GETKEYBOARDSPEED = 0x0a;
+
+
+        public RepeatableKeyboard()
+        {
+            {
+                int value;
+                SystemParametersInfo(SPI_GETKEYBOARDDELAY, 0, out value, 0);
+                keyboardDelay = 250 + 250 * value;
+            }
+            {
+                int value;
+                SystemParametersInfo(SPI_GETKEYBOARDSPEED, 0, out value, 0);
+                keyboardSpeed = 400 - 12 * value;
+            }
+        }
+
+        public void UnblockRepeats()
+        {
+            blockRepeats = false;
+        }
+
+        public bool IsKeyPressed(Keys key)
+        {
+            var pressed = key == lastPressed && isPressing && !blockRepeats;
+            if (pressed)
+            {
+                blockRepeats = true;
+            }
+            return pressed;
+        }
+
+        public void UpdateWith(KeyboardState keyboard, GameTime gameTime)
+        {
+            isPressing = false;
+
+            var downKeys = keyboard.GetPressedKeys();
+            if (downKeys.Length == 1)
+            {
+                var downKey = downKeys[0];
+
+                if (lastPressed == downKeys[0])
+                {
+                    nextRepeatInMillis -= gameTime.ElapsedGameTime.TotalMilliseconds;
+                    if (nextRepeatInMillis <= 0)
+                    {
+                        isPressing = true;
+
+                        nextRepeatInMillis = keyboardSpeed;
+                    }
+                }
+                else
+                {
+                    isPressing = true;
+                    lastPressed = downKeys[0];
+                    nextRepeatInMillis = keyboardDelay;
+                    blockRepeats = false;
+                }
+            }
+            else
+            {
+                lastPressed = Keys.None;
+            }
+        }
+    }
+}

--- a/OpenKh.Game/Infrastructure/RepeatableKeyboard.cs
+++ b/OpenKh.Game/Infrastructure/RepeatableKeyboard.cs
@@ -10,101 +10,40 @@ namespace OpenKh.Game.Infrastructure
 {
     class RepeatableKeyboard
     {
-        private bool isPressing = false;
-        private Keys lastPressed;
-        private double nextRepeatInMillis = 0;
-        private int keyboardDelay;
-        private int keyboardSpeed;
-        private bool blockRepeats = false;
+        public bool IsKeyPressed(Keys key) => GetKey(key).IsPressed;
+        public void PressKey(Keys key) => KeyStatePool[(int)key] = new KeyState { IsPressed = true };
+        public void ReleaseKey(Keys key) => KeyStatePool[(int)key] = new KeyState { IsPressed = false };
+        public void UpdateKey(Keys key, float seconds) => KeyStatePool[(int)key].Timer += seconds;
 
-        [DllImport("user32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        static extern bool SystemParametersInfo(int uiAction, int uiParam, out int pvParam, int fWinIni);
-
-        /// <summary>
-        /// Retrieves the keyboard repeat-delay setting, which is a value in the range from 0 (approximately 250 ms delay) through 3 (approximately 1 second delay). The actual delay associated with each value may vary depending on the hardware. The pvParam parameter must point to an integer variable that receives the setting.
-        /// </summary>
-        /// <remarks>
-        /// first:
-        /// 0 = 250 ms
-        /// 1 = 500 ms
-        /// 2 = 750 ms
-        /// 3 = 1000 ms
-        /// </remarks>
-        const int SPI_GETKEYBOARDDELAY = 0x16;
-
-        /// <summary>
-        /// Retrieves the keyboard repeat-speed setting, which is a value in the range from 0 (approximately 2.5 repetitions per second) through 31 (approximately 30 repetitions per second). The actual repeat rates are hardware-dependent and may vary from a linear scale by as much as 20%. The pvParam parameter must point to a DWORD variable that receives the setting.
-        /// </summary>
-        /// <remarks>
-        /// repeat:
-        /// 0 = 400 ms
-        /// ...
-        /// 31 = 33 ms
-        /// </remarks>
-        const int SPI_GETKEYBOARDSPEED = 0x0a;
-
-
-        public RepeatableKeyboard()
+        public bool IsKeyRepeat(Keys key)
         {
-            {
-                int value;
-                SystemParametersInfo(SPI_GETKEYBOARDDELAY, 0, out value, 0);
-                keyboardDelay = 250 + 250 * value;
-            }
-            {
-                int value;
-                SystemParametersInfo(SPI_GETKEYBOARDSPEED, 0, out value, 0);
-                keyboardSpeed = 400 - 12 * value;
-            }
+            if (!IsKeyPressed(key))
+                return false;
+            var keyState = KeyStatePool[(int)key];
+            var timer = keyState.Timer;
+            if (timer < MinimumRepeatTime)
+                return false;
+            timer -= MinimumRepeatTime;
+            if (timer < keyState.PressCount * ContinuousRepeatTime)
+                return false;
+            keyState.PressCount++;
+            KeyStatePool[(int)key] = keyState;
+            return true;
         }
 
-        public void UnblockRepeats()
+        const float MinimumRepeatTime = 1.0f; // seconds
+        const float ContinuousRepeatTime = 0.25f; // every 250ms
+
+        private const int MaxKeyCount = 256;
+
+        private KeyState[] KeyStatePool = new KeyState[MaxKeyCount];
+        private KeyState GetKey(Keys key) => KeyStatePool[(int)key];
+
+        private struct KeyState
         {
-            blockRepeats = false;
-        }
-
-        public bool IsKeyPressed(Keys key)
-        {
-            var pressed = key == lastPressed && isPressing && !blockRepeats;
-            if (pressed)
-            {
-                blockRepeats = true;
-            }
-            return pressed;
-        }
-
-        public void UpdateWith(KeyboardState keyboard, GameTime gameTime)
-        {
-            isPressing = false;
-
-            var downKeys = keyboard.GetPressedKeys();
-            if (downKeys.Length == 1)
-            {
-                var downKey = downKeys[0];
-
-                if (lastPressed == downKeys[0])
-                {
-                    nextRepeatInMillis -= gameTime.ElapsedGameTime.TotalMilliseconds;
-                    if (nextRepeatInMillis <= 0)
-                    {
-                        isPressing = true;
-
-                        nextRepeatInMillis = keyboardSpeed;
-                    }
-                }
-                else
-                {
-                    isPressing = true;
-                    lastPressed = downKeys[0];
-                    nextRepeatInMillis = keyboardDelay;
-                    blockRepeats = false;
-                }
-            }
-            else
-            {
-                lastPressed = Keys.None;
-            }
+            public bool IsPressed;
+            public float Timer;
+            public int PressCount;
         }
     }
 }

--- a/OpenKh.Game/Infrastructure/RepeatableKeyboard.cs
+++ b/OpenKh.Game/Infrastructure/RepeatableKeyboard.cs
@@ -11,28 +11,38 @@ namespace OpenKh.Game.Infrastructure
     class RepeatableKeyboard
     {
         public bool IsKeyPressed(Keys key) => GetKey(key).IsPressed;
-        public void PressKey(Keys key) => KeyStatePool[(int)key] = new KeyState { IsPressed = true };
+        public void PressKey(Keys key) => KeyStatePool[(int)key] = new KeyState { IsPressed = true, KeyDownFirstChance = true };
         public void ReleaseKey(Keys key) => KeyStatePool[(int)key] = new KeyState { IsPressed = false };
-        public void UpdateKey(Keys key, float seconds) => KeyStatePool[(int)key].Timer += seconds;
+        public void UpdateKey(Keys key, float seconds)
+        {
+            var state = KeyStatePool[(int)key];
+
+            state.Timer += seconds;
+            state.KeyDownFirstChance = false;
+
+            KeyStatePool[(int)key] = state;
+        }
 
         public bool IsKeyRepeat(Keys key)
         {
-            if (!IsKeyPressed(key))
+            var state = KeyStatePool[(int)key];
+            if (!state.IsPressed)
                 return false;
-            var keyState = KeyStatePool[(int)key];
-            var timer = keyState.Timer;
+            if (state.KeyDownFirstChance)
+                return true;
+            var timer = state.Timer;
             if (timer < MinimumRepeatTime)
                 return false;
             timer -= MinimumRepeatTime;
-            if (timer < keyState.PressCount * ContinuousRepeatTime)
+            if (timer < state.PressCount * ContinuousRepeatTime)
                 return false;
-            keyState.PressCount++;
-            KeyStatePool[(int)key] = keyState;
+            state.PressCount++;
+            KeyStatePool[(int)key] = state;
             return true;
         }
 
         const float MinimumRepeatTime = 1.0f; // seconds
-        const float ContinuousRepeatTime = 0.25f; // every 250ms
+        const float ContinuousRepeatTime = 0.05f; // every 50ms
 
         private const int MaxKeyCount = 256;
 
@@ -42,6 +52,7 @@ namespace OpenKh.Game.Infrastructure
         private struct KeyState
         {
             public bool IsPressed;
+            public bool KeyDownFirstChance;
             public float Timer;
             public int PressCount;
         }

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -88,7 +88,7 @@ namespace OpenKh.Game
 
         protected override void Update(GameTime gameTime)
         {
-            inputManager.Update();
+            inputManager.Update(gameTime);
             if (inputManager.IsExit)
                 Exit();
 
@@ -108,6 +108,7 @@ namespace OpenKh.Game
             state?.Draw(deltaTimes);
             _debugOverlay.Draw(deltaTimes);
             base.Draw(gameTime);
+            inputManager.UnblockRepeats();
         }
 
         private StateInitDesc GetStateInitDesc()

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -108,7 +108,6 @@ namespace OpenKh.Game
             state?.Draw(deltaTimes);
             _debugOverlay.Draw(deltaTimes);
             base.Draw(gameTime);
-            inputManager.UnblockRepeats();
         }
 
         private StateInitDesc GetStateInitDesc()


### PR DESCRIPTION
This pull request adds key pressing pulse in debugMenu.

![repeats](https://user-images.githubusercontent.com/5955540/83965549-66965600-a8ef-11ea-96d9-84508553996a.gif)

It uses actual SPI_GETKEYBOARDDELAY/SPI_GETKEYBOARDSPEED values obtained from [SystemParametersInfoA function (winuser.h) - Win32 apps | Microsoft Docs](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-systemparametersinfoa) Win32 API.
You can change it from `control.exe keyboard`