### PR TITLE
Implement logs

### DIFF
--- a/OpenKh.Game/DataContent/IdxDataContent.cs
+++ b/OpenKh.Game/DataContent/IdxDataContent.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using OpenKh.Game.Debugging;
 using OpenKh.Game.Infrastructure;
 using OpenKh.Kh2;
 
@@ -15,7 +16,10 @@ namespace OpenKh.Game.DataContent
 
         public bool FileExists(string fileName) => _img.FileExists(fileName);
 
-        public Stream FileOpen(string path) =>
-            _img.TryFileOpen(path, out var stream) ? stream : null;
+        public Stream FileOpen(string path)
+        {
+            Log.Info($"Load IDX file {path}");
+            return _img.TryFileOpen(path, out var stream) ? stream : null;
+        }
     }
 }

--- a/OpenKh.Game/DataContent/StandardDataContent.cs
+++ b/OpenKh.Game/DataContent/StandardDataContent.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using OpenKh.Game.Debugging;
 using OpenKh.Game.Infrastructure;
 
 namespace OpenKh.Game.DataContent
@@ -16,6 +17,7 @@ namespace OpenKh.Game.DataContent
 
         public Stream FileOpen(string path)
         {
+            Log.Info($"Load file {path}");
             var fileName = Path.Combine(_baseDirectory, path);
             if (File.Exists(fileName))
                 return File.OpenRead(fileName);

--- a/OpenKh.Game/Debugging/Log.cs
+++ b/OpenKh.Game/Debugging/Log.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenKh.Game.Debugging
+{
+    public static class Log
+    {
+        private const string LogFileName = "openkh.log";
+        private static Stopwatch _stopwatch = Stopwatch.StartNew();
+        private static StreamWriter _logWriter = new StreamWriter(LogFileName, false, Encoding.UTF8, 65536);
+
+        public static void Info(string text) => LogText("INF", text);
+        public static void Warn(string text) => LogText("WRN", text);
+        public static void Err(string text) => LogText("ERR", text);
+        public static void Throw(Exception ex)
+        {
+            LogText("EX!", ex.Message);
+            throw ex;
+        }
+
+        public static void Flush()
+        {
+            lock (_logWriter)
+            {
+                _logWriter.Flush();
+            }
+        }
+
+    private static void LogText(string tag, string text)
+        {
+            var ms = _stopwatch.ElapsedMilliseconds;
+            var str = $"[{ms:D6}ms] {tag} {text}";
+            Task.Run(() =>
+            {
+                Console.WriteLine(str);
+                lock (_logWriter)
+                {
+                    _logWriter.WriteLine(str);
+                }
+            });
+        }
+    }
+}

--- a/OpenKh.Game/Debugging/Log.cs
+++ b/OpenKh.Game/Debugging/Log.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenKh.Game.Debugging
@@ -11,31 +13,79 @@ namespace OpenKh.Game.Debugging
         private const string LogFileName = "openkh.log";
         private static Stopwatch _stopwatch = Stopwatch.StartNew();
         private static StreamWriter _logWriter = new StreamWriter(LogFileName, false, Encoding.UTF8, 65536);
+        private static Queue<string> _logQueue = new Queue<string>();
+        private static CancellationTokenSource _cancellationTokenSrc = new CancellationTokenSource();
+        private static Task _taskLog;
 
         public static void Info(string text) => LogText("INF", text);
         public static void Warn(string text) => LogText("WRN", text);
         public static void Err(string text) => LogText("ERR", text);
 
-        public static void Flush()
+        static Log()
         {
-            lock (_logWriter)
-            {
-                _logWriter.Flush();
-            }
+            _taskLog = Task.Run(LogWriterListener, _cancellationTokenSrc.Token);
         }
 
-    private static void LogText(string tag, string text)
+        public static void Close()
+        {
+            _cancellationTokenSrc.Cancel();
+            _cancellationTokenSrc.Token.WaitHandle.WaitOne();
+            _cancellationTokenSrc.Dispose();
+            Flush();
+        }
+
+        private static void Flush()
+        {
+            const int Timeout = 3000;
+
+            var timeoutStopwatch = Stopwatch.StartNew();
+            do
+            {
+                lock (_logQueue)
+                {
+                    if (_logQueue.Count == 0)
+                    {
+                        _logWriter.Flush();
+                        return;
+                    }
+                }
+            } while (timeoutStopwatch.ElapsedMilliseconds < Timeout);
+
+            throw new TimeoutException("Could not flush logs within the time limit");
+        }
+
+        private static void LogText(string tag, string text)
         {
             var ms = _stopwatch.ElapsedMilliseconds;
             var str = $"[{(ms/1000):D3}.{(ms%1000):D3}] {tag} {text}";
-            Task.Run(() =>
+            lock (_logQueue)
+                _logQueue.Enqueue(str);
+        }
+
+        private static void LogWriterListener()
+        {
+            while (!_cancellationTokenSrc.IsCancellationRequested)
             {
-                Console.WriteLine(str);
-                lock (_logWriter)
-                {
-                    _logWriter.WriteLine(str);
-                }
-            });
+                DequeueAllLogs();
+                Thread.Sleep(1);
+            }
+
+            DequeueAllLogs();
+        }
+
+        private static void DequeueAllLogs()
+        {
+            lock (_logQueue)
+            {
+                while (_logQueue.Count > 0)
+                    LogForReal(_logQueue.Dequeue());
+            }
+        }
+
+        private static void LogForReal(string str)
+        {
+            Console.WriteLine(str);
+            _logWriter.WriteLine(str);
         }
     }
 }

--- a/OpenKh.Game/Debugging/Log.cs
+++ b/OpenKh.Game/Debugging/Log.cs
@@ -15,11 +15,6 @@ namespace OpenKh.Game.Debugging
         public static void Info(string text) => LogText("INF", text);
         public static void Warn(string text) => LogText("WRN", text);
         public static void Err(string text) => LogText("ERR", text);
-        public static void Throw(Exception ex)
-        {
-            LogText("EX!", ex.Message);
-            throw ex;
-        }
 
         public static void Flush()
         {
@@ -32,7 +27,7 @@ namespace OpenKh.Game.Debugging
     private static void LogText(string tag, string text)
         {
             var ms = _stopwatch.ElapsedMilliseconds;
-            var str = $"[{ms:D6}ms] {tag} {text}";
+            var str = $"[{(ms/1000):D3}.{(ms%1000):D3}] {tag} {text}";
             Task.Run(() =>
             {
                 Console.WriteLine(str);

--- a/OpenKh.Game/Infrastructure/Kernel.cs
+++ b/OpenKh.Game/Infrastructure/Kernel.cs
@@ -1,8 +1,9 @@
-﻿using OpenKh.Common;
+using OpenKh.Common;
 using OpenKh.Common.Archives;
 using OpenKh.Engine;
 using OpenKh.Engine.Extensions;
 using OpenKh.Engine.Renders;
+using OpenKh.Game.Debugging;
 using OpenKh.Kh2;
 using OpenKh.Kh2.Battle;
 using OpenKh.Kh2.Contextes;
@@ -36,12 +37,16 @@ namespace OpenKh.Game.Infrastructure
 
         public Kernel(IDataContent dataContent)
         {
+            Log.Info("Initialize kernel");
             _dataContent = dataContent;
 
             FontContext = new FontContext();
             MessageProvider = new Kh2MessageProvider();
             RegionId = DetectRegion(dataContent);
+            Log.Info($"Region={Region} Language={Language}");
+
             IsReMix = IsReMixFileExists(dataContent, Region);
+            Log.Info($"ReMIX={IsReMix}");
 
             // Load files in the same order as KH2 does
             ObjEntries = LoadFile("00objentry.bin", stream => Objentry.Read(stream));
@@ -62,11 +67,13 @@ namespace OpenKh.Game.Infrastructure
 
             if (Language == "jp")
             {
+                Log.Info($"Use Japanese text encoding");
                 SystemMessageContext = FontContext.ToKh2JpSystemTextContext();
                 EventMessageContext = FontContext.ToKh2JpEventTextContext();
             }
             else
             {
+                Log.Info($"Use International text encoding");
                 SystemMessageContext = FontContext.ToKh2EuSystemTextContext();
                 EventMessageContext = FontContext.ToKh2EuEventTextContext();
             }
@@ -119,7 +126,10 @@ namespace OpenKh.Game.Infrastructure
             {
                 var testFileName = $"menu/{Constants.Regions[i]}/title.2ld";
                 if (dataContent.FileExists(testFileName))
+                {
+                    Log.Info($"RegionId={i}");
                     return i;
+                }
             }
 
             throw new Exception("Unable to detect any region for the game. Some files are potentially missing.");

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -4,6 +4,7 @@ using OpenKh.Game.DataContent;
 using OpenKh.Game.Debugging;
 using OpenKh.Game.Infrastructure;
 using OpenKh.Game.States;
+using OpenKh.Kh2;
 using System;
 using System.IO;
 
@@ -24,6 +25,7 @@ namespace OpenKh.Game
         {
             set
             {
+                Log.Info($"State={value}");
                 switch (value)
                 {
                     case 0:
@@ -40,6 +42,9 @@ namespace OpenKh.Game
                         _debugOverlay.OnUpdate = state.DebugUpdate;
                         _debugOverlay.OnDraw = state.DebugDraw;
                         break;
+                    default:
+                        Log.Err($"Invalid state {value}");
+                        break;
                 }    
             }
         }
@@ -48,7 +53,11 @@ namespace OpenKh.Game
         {
             _dataContent = CreateDataContent(".", "KH2.IDX", "KH2.IMG");
             if (Kernel.IsReMixFileHasHdAssetHeader(_dataContent, "fm"))
+            {
+                Log.Info("ReMIX files with HD asset header detected");
                 _dataContent = new HdAssetContent(_dataContent);
+            }
+
             _dataContent = new SafeDataContent(_dataContent);
 
             _kernel = new Kernel(_dataContent);
@@ -56,6 +65,7 @@ namespace OpenKh.Game
             var resolutionWidth = _kernel.IsReMix ?
                 Global.ResolutionRemixWidth :
                 Global.ResolutionWidth;
+            Log.Info($"Internal game resolution set to {resolutionWidth}x{Global.ResolutionHeight}");
 
             graphics = new GraphicsDeviceManager(this)
             {
@@ -134,8 +144,11 @@ namespace OpenKh.Game
 
         private static IDataContent CreateDataContent(string basePath, string idxFileName, string imgFileName)
         {
+            Log.Info($"Base directory is {basePath}");
             if (File.Exists(idxFileName) && File.Exists(imgFileName))
             {
+                Log.Info($"{idxFileName} and {imgFileName} has been found");
+
                 var imgStream = File.OpenRead(imgFileName);
                 var idxDataContent = File.OpenRead(idxFileName)
                     .Using(stream => new IdxDataContent(stream, imgStream));
@@ -146,7 +159,10 @@ namespace OpenKh.Game
                 );
             }
             else
+            {
+                Log.Info($"No {idxFileName} or {imgFileName}, loading extracted files");
                 return new StandardDataContent(basePath);
+            }
         }
     }
 }

--- a/OpenKh.Game/Program.cs
+++ b/OpenKh.Game/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using OpenKh.Game.Debugging;
+using System;
 
 namespace OpenKh.Game
 {
@@ -7,8 +8,31 @@ namespace OpenKh.Game
         [STAThread]
         static void Main()
         {
-            using (var game = new OpenKhGame())
-                game.Run();
+            Log.Info("Boot");
+
+            try
+            {
+                using (var game = new OpenKhGame())
+                    game.Run();
+            }
+            catch (Exception ex)
+            {
+                Log.Err("A fatal error has occurred. Please attach this log to https://github.com/xeeynamo/openkh/issues");
+                Catch(ex);
+                Log.Flush();
+
+                throw ex;
+            }
+
+            Log.Info("End");
+            Log.Flush();
+        }
+
+        private static void Catch(Exception ex)
+        {
+            Log.Err($"{ex.GetType().Name}: {ex.Message}:\n{ex.StackTrace}");
+            if (ex.InnerException != null)
+                Catch(ex.InnerException);
         }
     }
 }

--- a/OpenKh.Game/Program.cs
+++ b/OpenKh.Game/Program.cs
@@ -19,13 +19,13 @@ namespace OpenKh.Game
             {
                 Log.Err("A fatal error has occurred. Please attach this log to https://github.com/xeeynamo/openkh/issues");
                 Catch(ex);
-                Log.Flush();
+                Log.Close();
 
                 throw ex;
             }
 
             Log.Info("End");
-            Log.Flush();
+            Log.Close();
         }
 
         private static void Catch(Exception ex)

--- a/OpenKh.Game/States/MapState.cs
+++ b/OpenKh.Game/States/MapState.cs
@@ -273,6 +273,8 @@ namespace OpenKh.Game.States
 
         private void LoadMap(int worldIndex, int placeIndex)
         {
+            Log.Info($"Map={worldIndex},{placeIndex}");
+
             string fileName;
             if (_kernel.IsReMix)
                 fileName = $"map/{Constants.WorldIds[worldIndex]}{placeIndex:D02}.map";
@@ -288,10 +290,16 @@ namespace OpenKh.Game.States
         private static MeshGroup FromMdlx(
             GraphicsDevice graphics, ArchiveManager archiveManager, string modelName, string textureName)
         {
+            Log.Info($"Load model={modelName} texture={textureName}");
             var mdlx = archiveManager.Get<Mdlx>(modelName);
             var modelTextures = archiveManager.Get<ModelTexture>(textureName);
             if (mdlx == null)
+            {
+                Log.Warn($"model {modelName} is null");
                 return null;
+            }
+            if (textureName == null)
+                Log.Warn($"texture {modelName} is null");
 
             var textures = modelTextures?.Images?
                 .Select(texture => new KingdomTexture(texture, graphics)).ToArray() ?? new KingdomTexture[0];
@@ -347,7 +355,10 @@ namespace OpenKh.Game.States
         private void AddMesh(MeshGroup mesh)
         {
             if (mesh == null)
+            {
+                Log.Warn("AddMesh received null");
                 return;
+            }
 
             _models.Add(mesh);
         }

--- a/OpenKh.Game/States/TitleState.cs
+++ b/OpenKh.Game/States/TitleState.cs
@@ -181,6 +181,7 @@ namespace OpenKh.Game.States
             layoutRendererFg = CreateLayoutRenderer("titl");
             layoutRendererBg.SelectedSequenceGroupIndex = _titleLayout.Copyright;
 
+            Log.Info($"Theater={_titleLayout.HasTheater}");
             if (_titleLayout.HasTheater)
                 layoutRendererTheater = CreateLayoutRenderer("even");
 
@@ -320,6 +321,7 @@ namespace OpenKh.Game.States
 
         private void SetOption(int option)
         {
+            Log.Info($"TitleOption={option} prev={_optionSelected}");
             _optionSelected = option;
 
             switch (_optionSelected)


### PR DESCRIPTION
Something we missed from the start: a log system. This will help us to track performance, errors or to just study the games logic more once the engine will be less hard-coded.
The impact of logging is minimal, since the implementation is completely asynchronous.

This is an example of log:
```
[000.011] INF Boot
[000.792] INF Base directory is .
[000.794] INF No KH2.IDX or KH2.IMG, loading extracted files
[000.794] INF Load file menu/fm/titlejf.2ld
[000.818] INF Initialize kernel
[000.821] INF RegionId=2
[000.822] INF Region=uk Language=uk
[000.822] INF ReMIX=False
[000.823] INF Load file 00objentry.bin
[001.256] INF Load file 03system.bin
[001.356] INF Load file 00battle.bin
[001.447] INF Load file msg/uk/fontimage.bar
[001.468] ERR A fatal error has occurred. Please attach this log to https://github.com/xeeynamo/openkh/issues
[001.535] ERR FileNotFoundException: msg/uk/fontimage.bar:
   at OpenKh.Game.DataContent.SafeDataContent.FileOpen(String fileName) in .\openkh\OpenKh.Game\DataContent\SafeDataContent.cs:line 23
   at OpenKh.Game.Infrastructure.Kernel.LoadFontInfo(String fileName) in .\openkh\OpenKh.Game\Infrastructure\Kernel.cs:line 107
   at OpenKh.Game.Infrastructure.Kernel.LoadFontImage(String fileName) in .\openkh\OpenKh.Game\Infrastructure\Kernel.cs:line 113
   at OpenKh.Game.Infrastructure.Kernel..ctor(IDataContent dataContent) in .\openkh\OpenKh.Game\Infrastructure\Kernel.cs:line 62
   at OpenKh.Game.OpenKhGame..ctor() in .\openkh\OpenKh.Game\OpenKhGame.cs:line 63
   at OpenKh.Game.Program.Main() in .\openkh\OpenKh.Game\Program.cs:line 15
```