### PR TITLE
Change location for game content

### DIFF
--- a/OpenKh.Game/DataContent/StandardDataContent.cs
+++ b/OpenKh.Game/DataContent/StandardDataContent.cs
@@ -8,21 +8,23 @@ namespace OpenKh.Game.DataContent
     {
         private readonly string _baseDirectory;
 
-        public StandardDataContent(string baseDirectory = ".")
+        public StandardDataContent(string baseDirectory)
         {
             _baseDirectory = baseDirectory;
         }
 
-        public bool FileExists(string fileName) => File.Exists(fileName);
+        public bool FileExists(string fileName) => File.Exists(GetPath(fileName));
 
         public Stream FileOpen(string path)
         {
             Log.Info($"Load file {path}");
-            var fileName = Path.Combine(_baseDirectory, path);
+            var fileName = GetPath(path);
             if (File.Exists(fileName))
                 return File.OpenRead(fileName);
 
             return null;
         }
+
+        private string GetPath(string path) => Path.Combine(_baseDirectory, path);
     }
 }

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -13,7 +13,7 @@ namespace OpenKh.Game
 {
     public class OpenKhGame : Microsoft.Xna.Framework.Game, IStateChange
     {
-        private const string DefaultContentPath = "./data";
+        private const string DefaultContentPath = ".";
         private GraphicsDeviceManager graphics;
 
         private readonly IDataContent _dataContent;

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -7,11 +7,13 @@ using OpenKh.Game.States;
 using OpenKh.Kh2;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace OpenKh.Game
 {
     public class OpenKhGame : Microsoft.Xna.Framework.Game, IStateChange
     {
+        private const string DefaultContentPath = ".";
         private GraphicsDeviceManager graphics;
 
         private readonly IDataContent _dataContent;
@@ -49,9 +51,11 @@ namespace OpenKh.Game
             }
         }
 
-        public OpenKhGame()
+        public OpenKhGame(string[] args)
         {
-            _dataContent = CreateDataContent(".", "KH2.IDX", "KH2.IMG");
+            var contentPath = args.FirstOrDefault() ?? DefaultContentPath;
+
+            _dataContent = CreateDataContent(contentPath, "KH2.IDX", "KH2.IMG");
             if (Kernel.IsReMixFileHasHdAssetHeader(_dataContent, "fm"))
             {
                 Log.Info("ReMIX files with HD asset header detected");

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -13,7 +13,7 @@ namespace OpenKh.Game
 {
     public class OpenKhGame : Microsoft.Xna.Framework.Game, IStateChange
     {
-        private const string DefaultContentPath = ".";
+        private const string DefaultContentPath = "./data";
         private GraphicsDeviceManager graphics;
 
         private readonly IDataContent _dataContent;

--- a/OpenKh.Game/Program.cs
+++ b/OpenKh.Game/Program.cs
@@ -6,14 +6,14 @@ namespace OpenKh.Game
     public static class Program
     {
         [STAThread]
-        static void Main()
+        static void Main(string[] args)
         {
             Log.Info("Boot");
 
             try
             {
-                using (var game = new OpenKhGame())
-                    game.Run();
+                using (var game = new OpenKhGame(args))
+                        game.Run();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Previously you had to put all the game files into the same directory where binaries were located. I changed it to fetch game data from the folder "data".
It is also possible to specify the game data directory through command line, so you can just invoke `dotnet OpenKh.Game.dll /mnt/disc0`.