### PR TITLE
Fix KH2.IDX path argument

### DIFF
--- a/OpenKh.Game/OpenKh.Game.csproj
+++ b/OpenKh.Game/OpenKh.Game.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <InformationalVersion>0.0.0.0-local</InformationalVersion>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -149,12 +149,15 @@ namespace OpenKh.Game
         private static IDataContent CreateDataContent(string basePath, string idxFileName, string imgFileName)
         {
             Log.Info($"Base directory is {basePath}");
-            if (File.Exists(idxFileName) && File.Exists(imgFileName))
-            {
-                Log.Info($"{idxFileName} and {imgFileName} has been found");
 
-                var imgStream = File.OpenRead(imgFileName);
-                var idxDataContent = File.OpenRead(idxFileName)
+            var idxFullPath = Path.Combine(basePath, idxFileName);
+            var imgFullPath = Path.Combine(basePath, imgFileName);
+            if (File.Exists(idxFullPath) && File.Exists(imgFullPath))
+            {
+                Log.Info($"{idxFullPath} and {imgFullPath} has been found");
+
+                var imgStream = File.OpenRead(imgFullPath);
+                var idxDataContent = File.OpenRead(idxFullPath)
                     .Using(stream => new IdxDataContent(stream, imgStream));
                 return new MultipleDataContent(
                     new StandardDataContent(basePath),
@@ -164,7 +167,7 @@ namespace OpenKh.Game
             }
             else
             {
-                Log.Info($"No {idxFileName} or {imgFileName}, loading extracted files");
+                Log.Info($"No {idxFullPath} or {imgFullPath}, loading extracted files");
                 return new StandardDataContent(basePath);
             }
         }

--- a/OpenKh.Game/Program.cs
+++ b/OpenKh.Game/Program.cs
@@ -10,6 +10,10 @@ namespace OpenKh.Game
         {
             Log.Info("Boot");
 
+#if DEBUG
+            using (var game = new OpenKhGame(args))
+                game.Run();
+#else
             try
             {
                 using (var game = new OpenKhGame(args))
@@ -23,6 +27,7 @@ namespace OpenKh.Game
 
                 throw ex;
             }
+#endif
 
             Log.Info("End");
             Log.Close();

--- a/OpenKh.Game/Program.cs
+++ b/OpenKh.Game/Program.cs
@@ -1,14 +1,18 @@
 ﻿using OpenKh.Game.Debugging;
 using System;
+using System.Reflection;
 
 namespace OpenKh.Game
 {
     public static class Program
     {
+        public static readonly string ProductVersion = typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+
         [STAThread]
         static void Main(string[] args)
         {
             Log.Info("Boot");
+            Log.Info($"Version {ProductVersion}");
 
 #if DEBUG
             using (var game = new OpenKhGame(args))


### PR DESCRIPTION
* Game could not find KH2.IDX when passing the data path as argument
* Exceptions were always caught, making debugging harder. It is now fixed.
* Printing version of the game in logs, so it would be easier to understand which version was causing a specific crash.