### PR TITLE
KH2 IdxImg improvements

### DIFF
--- a/OpenKh.Command.IdxImg/Program.cs
+++ b/OpenKh.Command.IdxImg/Program.cs
@@ -83,7 +83,7 @@ namespace OpenKh.Command.IdxImg
             protected int OnExecute(CommandLineApplication app)
             {
                 var inputImg = InputImg ?? InputIdx.Replace(".idx", ".img", StringComparison.InvariantCultureIgnoreCase);
-                var outputDir = OutputDir ?? Path.Combine(Path.GetFullPath(inputImg), "extract");
+                var outputDir = OutputDir ?? Path.Combine(Path.GetDirectoryName(inputImg), "extract");
 
                 var idxEntries = OpenIdx(InputIdx);
 

--- a/OpenKh.Command.IdxImg/Program.cs
+++ b/OpenKh.Command.IdxImg/Program.cs
@@ -64,7 +64,7 @@ namespace OpenKh.Command.IdxImg
 
             [Required]
             [FileExists]
-            [Argument(0, Description = "Kingdom Hearts II IDX file, paired with a IMG")]
+            [Argument(0, Description = "Kingdom Hearts II IDX file")]
             public string InputIdx { get; set; }
 
             [FileExists]
@@ -271,6 +271,9 @@ namespace OpenKh.Command.IdxImg
         private static IEnumerable<Idx.Entry> OpenIdx(string fileName)
         {
             using var idxStream = File.OpenRead(fileName);
+            if (!Idx.IsValid(idxStream))
+                throw new CustomException($"The IDX {fileName} is invalid or not recognized.");
+
             return Idx.Read(idxStream);
         }
     }

--- a/OpenKh.Kh2/Idx.cs
+++ b/OpenKh.Kh2/Idx.cs
@@ -106,7 +106,7 @@ namespace OpenKh.Kh2
         /// <param name="stream">Readable stream where the IDX has been serialized.</param>
         /// <returns></returns>
         public static List<Entry> Read(Stream stream) => Enumerable
-            .Range(0, stream.ReadInt32())
+            .Range(0, stream.SetPosition(0).ReadInt32())
             .Select(_ => BinaryMapping.ReadObject<Entry>(stream))
             .ToList();
 

--- a/OpenKh.Kh2/IdxName.cs
+++ b/OpenKh.Kh2/IdxName.cs
@@ -1,13 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace OpenKh.Kh2
 {
     public class IdxName
     {
         private static Dictionary<long, string> _nameDictionary = File
-            .ReadAllLines("resources/kh2idx.txt")
+            .ReadAllLines(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "resources/kh2idx.txt"))
             .ToDictionary(name => IdxDictionary.GetHash(name), name => name);
 
         public Idx.Entry Entry { get; set; }

--- a/docs/tool/index.md
+++ b/docs/tool/index.md
@@ -10,6 +10,7 @@
 
 | File | Tool name
 |------|-----------
+|[IDX](../kh2/file/type/msg.md) | OpenKh.Command.IdxImg
 |[msg/*](../kh2/file/type/msg.md) | OpenKh.Command.MsgTool
 |[msg/*](../kh2/file/type/msg.md) | [OpenKh.Tools.Kh2TextEditor](./Kh2TextEditor/index.md)
 |[BAR](../kh2/file/type/bar.md) | OpenKh.Tools.BarEditor

--- a/docs/tool/index.md
+++ b/docs/tool/index.md
@@ -10,7 +10,7 @@
 
 | File | Tool name
 |------|-----------
-|[IDX](../kh2/file/type/msg.md) | OpenKh.Command.IdxImg
+|[IDX](../kh2/file/type/idx.md) | OpenKh.Command.IdxImg
 |[msg/*](../kh2/file/type/msg.md) | OpenKh.Command.MsgTool
 |[msg/*](../kh2/file/type/msg.md) | [OpenKh.Tools.Kh2TextEditor](./Kh2TextEditor/index.md)
 |[BAR](../kh2/file/type/bar.md) | OpenKh.Tools.BarEditor


### PR DESCRIPTION
Fix the following issues:

* Program crashed if the output directory was not specified.
* Program crashed when the tool was called from a different directory.
* Program was stuck in a potential endless loop when an invalid IDX file was passed.
* Tool was not shown to Tools page in OpenKH docs