### PR TITLE
Fix 4-bpp imd/imz generator of `OpenKh.Command.ImgTool` and so on

### DIFF
--- a/OpenKh.Command.ImgTool/OpenKh.Command.ImgTool.csproj
+++ b/OpenKh.Command.ImgTool/OpenKh.Command.ImgTool.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="YamlDotNet" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenKh.Command.ImgTool/Utils/ImgdBitmapUtil.cs
+++ b/OpenKh.Command.ImgTool/Utils/ImgdBitmapUtil.cs
@@ -219,7 +219,7 @@ namespace OpenKh.Command.ImgTool.Utils
                             );
                         }
 
-                        var destBits = new byte[src.Width * src.Height];
+                        var destBits = new byte[(src.Width * src.Height + 1) / 2];
                         var clut = new byte[4 * maxColors];
 
                         for (int index = 0; index < newPalette.MostUsedPixels.Length; index++)

--- a/OpenKh.Command.ImgTool/Utils/ImgdBitmapUtil.cs
+++ b/OpenKh.Command.ImgTool/Utils/ImgdBitmapUtil.cs
@@ -242,13 +242,13 @@ namespace OpenKh.Command.ImgTool.Utils
                                 var newPixel = newPalette.FindNearest(src.Pixels[srcPointer++]) & 15;
                                 if (0 == (x & 1))
                                 {
-                                    // hi byte
-                                    destBits[destPointer] = (byte)(newPixel << 4);
+                                    // first pixel: lo byte
+                                    destBits[destPointer] = (byte)(newPixel);
                                 }
                                 else
                                 {
-                                    // lo byte
-                                    destBits[destPointer++] |= (byte)(newPixel);
+                                    // second pixel: hi byte
+                                    destBits[destPointer++] |= (byte)(newPixel << 4);
                                 }
                             }
                         }


### PR DESCRIPTION
Fixed 2 problems in ImgdBitmapUtil of `OpenKh.Command.ImgTool`:

1. 4bpp bitmap size is doubled. https://github.com/Xeeynamo/OpenKh/issues/162#issuecomment-660421260
2. 4bpp bitmap pixel-order is invalid. https://github.com/Xeeynamo/OpenKh/issues/162#issuecomment-660431065

Also added 4 commands. `fix-imz` and `swap-imz-pixel`  for fixing 1 and 2. `scan-imd` and `scan-imz` for diagnostics purpose.

```
Commands:
  fix-imz         imz file -> imz file (fix 4-bpp doubled bitmap size)
  scan-imd        imd file -> display summary
  scan-imz        imz file -> display summary
  swap-imz-pixel  imz file -> imz file (swap 4-bpp hi/lo pixel)
```

scan-imz:

```bat
OpenKh.Command.ImgTool.exe scan-imz C:\Users\KU\Desktop\title_aq_test.imz

0:
  PixelFormat: Indexed8
  Width: 128
  Height: 128
  IsSwizzled: false
  ExpectedDataLen: 16384
  ActualDataLen: 16384
  ActualClutLen: 1024
1:
  PixelFormat: Indexed8
  Width: 256
  Height: 256
  IsSwizzled: false
  ExpectedDataLen: 65536
  ActualDataLen: 65536
  ActualClutLen: 1024
2:
  PixelFormat: Indexed4
  Width: 512
  Height: 512
  IsSwizzled: false
  ExpectedDataLen: 131072
  ActualDataLen: 262144
  ActualClutLen: 64
3:
  PixelFormat: Indexed4
  Width: 768
  Height: 768
  IsSwizzled: false
  ExpectedDataLen: 294912
  ActualDataLen: 589824
  ActualClutLen: 64
4:
  PixelFormat: Indexed8
  Width: 768
  Height: 768
  IsSwizzled: false
  ExpectedDataLen: 589824
  ActualDataLen: 589824
  ActualClutLen: 1024
5:
  PixelFormat: Indexed4
  Width: 512
  Height: 512
  IsSwizzled: false
  ExpectedDataLen: 131072
  ActualDataLen: 262144
  ActualClutLen: 64
6:
  PixelFormat: Indexed4
  Width: 512
  Height: 512
  IsSwizzled: false
  ExpectedDataLen: 131072
  ActualDataLen: 262144
  ActualClutLen: 64
7:
  PixelFormat: Indexed8
  Width: 512
  Height: 256
  IsSwizzled: false
  ExpectedDataLen: 131072
  ActualDataLen: 131072
  ActualClutLen: 1024
8:
  PixelFormat: Indexed4
  Width: 256
  Height: 128
  IsSwizzled: false
  ExpectedDataLen: 16384
  ActualDataLen: 32768
  ActualClutLen: 64
```

scan-imd:

```bat
OpenKh.Command.ImgTool.exe scan-imd H:\KH2fm.yaz0r\itempic\item-000.imd

PixelFormat: Indexed8
Width: 128
Height: 128
IsSwizzled: false
ExpectedDataLen: 16384
ActualDataLen: 16384
ActualClutLen: 1024
```

fix-imz:

```bat
OpenKh.Command.ImgTool.exe fix-imz C:\Users\KU\Desktop\title_aq_test.imz

Fixed 5 images.
```

swap-imz-pixel:

```bat
OpenKh.Command.ImgTool.exe swap-imz-pixel C:\Users\KU\Desktop\title_aq_test.imz

Applied to 5 images.
```

![2020-07-18_15h09_19](https://user-images.githubusercontent.com/5955540/87846158-a9911380-c908-11ea-9b30-8f00f452381f.png)

[title_aq_test.zip](https://github.com/Xeeynamo/OpenKh/files/4941170/title_aq_test.zip)


Fix #162