### PR TITLE
Fix pixel-swap on loading 4-bpp imd/imz images

### DIFF
--- a/OpenKh.Engine/Extensions/ImageReadExtensions.cs
+++ b/OpenKh.Engine/Extensions/ImageReadExtensions.cs
@@ -44,8 +44,8 @@ namespace OpenKh.Engine.Extensions
                 for (var i = 0; i < size.Width / 2; i++)
                 {
                     var ch = data[srcIndex++];
-                    var palIndex1 = (ch >> 4);
-                    var palIndex2 = (ch & 15);
+                    var palIndex1 = (ch & 15);
+                    var palIndex2 = (ch >> 4);
                     dstData[dstIndex++] = clut[palIndex1 * 4 + channelOrder[0]];
                     dstData[dstIndex++] = clut[palIndex1 * 4 + channelOrder[1]];
                     dstData[dstIndex++] = clut[palIndex1 * 4 + channelOrder[2]];

--- a/OpenKh.Imaging/ImageDataHelpers.cs
+++ b/OpenKh.Imaging/ImageDataHelpers.cs
@@ -25,8 +25,8 @@ namespace OpenKh.Imaging
             for (int i = 0; i < data.Length; i++)
             {
                 var subData = data[i];
-                var clutIndex1 = subData >> 4;
-                var clutIndex2 = subData & 0x0F;
+                var clutIndex1 = subData & 0x0F;
+                var clutIndex2 = subData >> 4;
                 bitmap[i * 8 + 0] = clut[clutIndex1 * 4 + 2];
                 bitmap[i * 8 + 1] = clut[clutIndex1 * 4 + 1];
                 bitmap[i * 8 + 2] = clut[clutIndex1 * 4 + 0];

--- a/OpenKh.Kh2/RawBitmap.cs
+++ b/OpenKh.Kh2/RawBitmap.cs
@@ -31,9 +31,6 @@ namespace OpenKh.Kh2
             var bpp = is8bit ? 8 : 4;
             _data = reader.ReadBytes(width * height * bpp / 8);
 
-            if (is8bit == false)
-                _data = SwapBitOrder(_data);
-
             // If we did not reached the end of the stream, then it does mean that there is a palette
             if (stream.Position < stream.Length)
             {


### PR DESCRIPTION
There are pixel-swap problems when converting from 4-bpp bitmap data to native bitmap. Currently there are 3 parts doing this:

- `OpenKh.Engine/Extensions/ImageReadExtensions.cs` for `XNA` tools usage
- `OpenKh.Imaging/ImageDataHelpers.cs` for `WPF` tools usage
- ` GDI+` usage fixed by #164 

This pull requests fixes `XNA` and `WPF` parts.

`OpenKh.Tools.ImageViewer`

![2020-07-19_11h39_08](https://user-images.githubusercontent.com/5955540/87865902-a43dd280-c9b5-11ea-800f-6320ecc62c51.png)

`OpenKh.Game`

![2020-07-19_11h47_10](https://user-images.githubusercontent.com/5955540/87865901-9b4d0100-c9b5-11ea-925a-323863ce3ae5.png)


Fix #165 