### PR TITLE
Internally swap swizzled 4bpp IMGD files

### DIFF
--- a/OpenKh.Kh2/Ps2.Reform4.cs
+++ b/OpenKh.Kh2/Ps2.Reform4.cs
@@ -60,13 +60,13 @@
 									byte num16 = buffer[num15 / 2];
 									if ((num15 & 1) == 0)
 									{
-										num16 = (byte)(num16 & 15);
-										num16 = (byte)(num16 | ((byte)(num12 << 4)));
+										num16 = (byte)(num16 & 240);
+										num16 = (byte)(num16 | num12);
 									}
 									else
 									{
-										num16 = (byte)(num16 & 240);
-										num16 = (byte)(num16 | num12);
+										num16 = (byte)(num16 & 15);
+										num16 = (byte)(num16 | ((byte)(num12 << 4)));
 									}
 									buffer[num15 / 2] = num16;
 								}
@@ -103,11 +103,11 @@
 									byte num13 = bin[num12 / 2];
 									if ((num12 & 1) != 0)
 									{
-										num13 = (byte)(num13 & 15);
+										num13 = (byte)(num13 >> 4);
 									}
 									else
 									{
-										num13 = (byte)(num13 >> 4);
+										num13 = (byte)(num13 & 15);
 									}
 									int num14 = numArray[num9] / 8;
 									int num15 = numArray[num9] % 8;

--- a/OpenKh.Kh2/RawBitmap.cs
+++ b/OpenKh.Kh2/RawBitmap.cs
@@ -125,16 +125,5 @@ namespace OpenKh.Kh2
 
             return palette;
         }
-
-        private static byte[] SwapBitOrder(byte[] data)
-        {
-            for (var i = 0; i < data.Length; i++)
-            {
-                var ch = data[i];
-                data[i] = (byte)((ch >> 4) | (ch << 4));
-            }
-
-            return data;
-        }
     }
 }


### PR DESCRIPTION
This pull request fix a regression from #164 to fix #165 .

![before the PR](https://user-images.githubusercontent.com/6128729/88039916-1b06d700-cb40-11ea-9d05-d1feb59e1930.png)

#164 fixes the useless logic of swapping twice some bitmaps, but unfortunately it was swapping 4bpp endianness for some IMGD that were not supposed to be swapped too. I figured out that it was enough to change the 4bpp un/swizzling logic.

This is 100% accurate to what PlayStation 2 internally does. Image creation is fixed as well.