### PR TITLE
Fix flipped map glitch

### DIFF
--- a/OpenKh.Engine/Parsers/MdlxParser.cs
+++ b/OpenKh.Engine/Parsers/MdlxParser.cs
@@ -31,7 +31,7 @@ namespace OpenKh.Engine.Parsers
                     {
                         Vertices = x.Vertices.Select(vertex => new PositionColoredTextured
                         {
-                            X = vertex.X,
+                            X = -vertex.X,
                             Y = vertex.Y,
                             Z = vertex.Z,
                             U = vertex.Tu,
@@ -104,7 +104,7 @@ namespace OpenKh.Engine.Parsers
                 {
                     var vertexIndex = vpu.Indices[i];
                     var position = new Vector3(
-                        -vpu.Vertices[vertexIndex.Index].X,
+                        vpu.Vertices[vertexIndex.Index].X,
                         vpu.Vertices[vertexIndex.Index].Y,
                         vpu.Vertices[vertexIndex.Index].Z);
 

--- a/OpenKh.Game/States/MapState.cs
+++ b/OpenKh.Game/States/MapState.cs
@@ -93,7 +93,7 @@ namespace OpenKh.Game.States
 
             _graphics.GraphicsDevice.RasterizerState = new RasterizerState()
             {
-                CullMode = CullMode.CullClockwiseFace
+                CullMode = CullMode.CullCounterClockwiseFace
             };
             _graphics.GraphicsDevice.DepthStencilState = new DepthStencilState();
             _graphics.GraphicsDevice.BlendState = DefaultBlendState;


### PR DESCRIPTION
As the screenshot shows. The only problem is that now character models are flipped. But that is because OpenKH did not fully reversed those yet.

![image](https://user-images.githubusercontent.com/6128729/88392350-bce22a00-cdb3-11ea-9f1c-882c8517ad65.png)
