### PR TITLE
Fix various major issues with Layout Editor

### DIFF
--- a/OpenKh.Tools.LayoutEditor/AppLayoutEditor.cs
+++ b/OpenKh.Tools.LayoutEditor/AppLayoutEditor.cs
@@ -232,7 +232,7 @@ namespace OpenKh.Tools.LayoutEditor
                 sequenceProperty.AnimationGroup = sequenceProperty.AnimationGroup;
 
             var frameStart = sequenceProperty.ShowAtFrame;
-            if (ImGui.DragInt($"Show at frame##{index}", ref animGroupIndex))
+            if (ImGui.DragInt($"Show at frame##{index}", ref frameStart))
                 sequenceProperty.ShowAtFrame = frameStart;
 
             var position = new int[] { sequenceProperty.PositionX, sequenceProperty.PositionY };

--- a/OpenKh.Tools.LayoutEditor/AppLayoutEditor.cs
+++ b/OpenKh.Tools.LayoutEditor/AppLayoutEditor.cs
@@ -225,11 +225,19 @@ namespace OpenKh.Tools.LayoutEditor
 
             var sequenceIndex = sequenceProperty.SequenceIndex;
             if (ImGui.DragInt($"Sequence index##{index}", ref sequenceIndex))
+            {
                 sequenceProperty.SequenceIndex = Math.Min(Math.Max(sequenceIndex, 0), _layout.SequenceItems.Count - 1);
+                var sequence = _layout.SequenceItems[sequenceProperty.SequenceIndex];
+                sequenceProperty.AnimationGroup = Math.Min(Math.Max(sequenceProperty.AnimationGroup, 0), sequence.AnimationGroups.Count - 1);
+
+            }
 
             var animGroupIndex = sequenceProperty.AnimationGroup;
             if (ImGui.DragInt($"Animation group index##{index}", ref animGroupIndex))
-                sequenceProperty.AnimationGroup = sequenceProperty.AnimationGroup;
+            {
+                var sequence = _layout.SequenceItems[sequenceProperty.SequenceIndex];
+                sequenceProperty.AnimationGroup = Math.Min(Math.Max(sequenceProperty.AnimationGroup, 0), sequence.AnimationGroups.Count - 1);
+            }
 
             var frameStart = sequenceProperty.ShowAtFrame;
             if (ImGui.DragInt($"Show at frame##{index}", ref frameStart))

--- a/OpenKh.Tools.LayoutEditor/AppSequenceEditor.cs
+++ b/OpenKh.Tools.LayoutEditor/AppSequenceEditor.cs
@@ -384,6 +384,10 @@ namespace OpenKh.Tools.LayoutEditor
                 animation.FrameEnd = framePair[1];
             }
 
+            int spriteGroupIndex = animation.SpriteGroupIndex;
+            if (ImGui.InputInt($"Sprite group##{index}", ref spriteGroupIndex))
+                animation.SpriteGroupIndex = spriteGroupIndex;
+
             var xaPair = new int[] { animation.TranslateXStart, animation.TranslateXEnd };
             if (ImGui.DragInt2($"Translation X##{index}", ref xaPair[0]))
             {

--- a/OpenKh.Tools.LayoutEditor/AppSequenceEditor.cs
+++ b/OpenKh.Tools.LayoutEditor/AppSequenceEditor.cs
@@ -386,7 +386,7 @@ namespace OpenKh.Tools.LayoutEditor
 
             int spriteGroupIndex = animation.SpriteGroupIndex;
             if (ImGui.InputInt($"Sprite group##{index}", ref spriteGroupIndex))
-                animation.SpriteGroupIndex = spriteGroupIndex;
+                animation.SpriteGroupIndex = Math.Min(Math.Max(spriteGroupIndex, 0), _sequence.SpriteGroups.Count - 1);
 
             var xaPair = new int[] { animation.TranslateXStart, animation.TranslateXEnd };
             if (ImGui.DragInt2($"Translation X##{index}", ref xaPair[0]))

--- a/OpenKh.Tools.LayoutEditor/Controls/ImSequencer.cs
+++ b/OpenKh.Tools.LayoutEditor/Controls/ImSequencer.cs
@@ -177,7 +177,7 @@ namespace OpenKh.Tools.LayoutEditor.Controls
         {
             var io = ImGui.GetIO();
             var rect = new ImRect(pos, new Vector2(pos.X + 16, pos.Y + 16));
-            var isMouseOver = rect.Contains(io.MousePos) && ImGui.IsWindowFocused();
+            var isMouseOver = rect.Contains(io.MousePos);
             if (!isSelected)
                 color = isMouseOver ? 0xFFFFFFFFu : 0x50FFFFFFu;
 

--- a/OpenKh.Tools.LayoutEditor/Controls/ImSequencer.cs
+++ b/OpenKh.Tools.LayoutEditor/Controls/ImSequencer.cs
@@ -406,7 +406,8 @@ namespace OpenKh.Tools.LayoutEditor.Controls
                     var tPos = new Vector2(contentMin.X + 3, contentMin.Y + i * ItemHeight + 2 + customHeight);
                     var tEndPos = new Vector2(contentMin.X + 3 + legendWidth, contentMin.Y + (i + 1) * ItemHeight + 2 + customHeight);
                     var canMouseClickOnRow = new ImRect(tPos, tEndPos).Contains(io.MousePos) &&
-                        io.MousePos.Y > childFramePos.Y && io.MousePos.Y <= childFramePos.Y + childFrameSize.Y;
+                        io.MousePos.Y > childFramePos.Y && io.MousePos.Y <= childFramePos.Y + childFrameSize.Y &&
+                        ImGui.IsWindowFocused();
                     if (canMouseClickOnRow && io.MouseDown[0] && ImGui.IsWindowHovered())
                         selectedEntry = i;
 

--- a/OpenKh.Tools.LayoutEditor/Controls/ImSequencer.cs
+++ b/OpenKh.Tools.LayoutEditor/Controls/ImSequencer.cs
@@ -27,9 +27,7 @@
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
-using System.Windows.Controls;
 
 namespace OpenKh.Tools.LayoutEditor.Controls
 {
@@ -129,7 +127,6 @@ namespace OpenKh.Tools.LayoutEditor.Controls
         }
 
         private const float AnimationBarSideSelectionWidth = 8f;
-        private const int scrollBarHeight = 14;
         private const float MinBarWidth = 44f;
         private const float FLT_EPSILON = 1.192092896e-07F;
         private const uint ColorWhite = 0xffffffff;
@@ -236,7 +233,6 @@ namespace OpenKh.Tools.LayoutEditor.Controls
             var customDraws = new List<CustomDraw>();
             var compactCustomDraws = new List<CustomDraw>();
             // zoom in/out
-            int frameOverCursor = 0;
             int visibleFrameCount = (int)Math.Floor((canvas_size.X - legendWidth) / framePixelWidth);
             float barWidthRatio = Math.Min(visibleFrameCount / (float)frameCount, 1f);
             float barWidthInPixels = barWidthRatio * (canvas_size.X - legendWidth);

--- a/OpenKh.Tools.LayoutEditor/Controls/ImSequencer.cs
+++ b/OpenKh.Tools.LayoutEditor/Controls/ImSequencer.cs
@@ -80,7 +80,7 @@ namespace OpenKh.Tools.LayoutEditor.Controls
         {
             bool focused { get; set; }
             int FrameMin { get; }
-            int FrameMax { get;  }
+            int FrameMax { get; }
             bool IsPaused { get; set; }
             int ItemCount { get; }
             bool ForceLoop { get; set; }
@@ -177,10 +177,10 @@ namespace OpenKh.Tools.LayoutEditor.Controls
         {
             var io = ImGui.GetIO();
             var rect = new ImRect(pos, new Vector2(pos.X + 16, pos.Y + 16));
-            var isMouseOver = rect.Contains(io.MousePos);
+            var isMouseOver = rect.Contains(io.MousePos) && ImGui.IsWindowFocused();
             if (!isSelected)
                 color = isMouseOver ? 0xFFFFFFFFu : 0x50FFFFFFu;
-            
+
             draw_list.AddRect(rect.Min, rect.Max, color, 4);
             draw_list.AddText(new Vector2(pos.X + 4, pos.Y - 1), color, $"{ch}");
 
@@ -372,7 +372,7 @@ namespace OpenKh.Tools.LayoutEditor.Controls
 
                 Action<int, int> drawLine = (int i, int regionHeight) => {
                     const uint TextColor = 0xFFBBBBBB;
-                    
+
                     bool baseIndex = ((i % modFrameCount) == 0) || (i == sequence.FrameMax || i == sequence.FrameMin);
                     bool halfIndex = (i % halfModFrameCount) == 0;
                     int px = (int)canvas_pos.X + (int)(i * framePixelWidth) + legendWidth - (int)(firstFrameUsed * framePixelWidth);
@@ -411,7 +411,7 @@ namespace OpenKh.Tools.LayoutEditor.Controls
                     var tEndPos = new Vector2(contentMin.X + 3 + legendWidth, contentMin.Y + (i + 1) * ItemHeight + 2 + customHeight);
                     var canMouseClickOnRow = new ImRect(tPos, tEndPos).Contains(io.MousePos) &&
                         io.MousePos.Y > childFramePos.Y && io.MousePos.Y <= childFramePos.Y + childFrameSize.Y;
-                    if (canMouseClickOnRow && io.MouseDown[0])
+                    if (canMouseClickOnRow && io.MouseDown[0] && ImGui.IsWindowHovered())
                         selectedEntry = i;
 
                     draw_list.AddText(tPos, 0xFFFFFFFF, animation.Name ?? $"#{i + 1}");

--- a/OpenKh.Tools.LayoutEditor/Controls/ImSequencer.cs
+++ b/OpenKh.Tools.LayoutEditor/Controls/ImSequencer.cs
@@ -423,7 +423,7 @@ namespace OpenKh.Tools.LayoutEditor.Controls
                         if (SequencerButton(draw_list, buttonPos, 'H', !isAnimationVisible, 0xff15208f) && canMouseClickOnRow)
                         {
                             Tooltip("Hide animation");
-                            if (io.MouseDown[0])
+                            if (io.MouseReleased[0])
                                 sequence.SetVisibility(i, !isAnimationVisible);
                         }
 
@@ -432,7 +432,7 @@ namespace OpenKh.Tools.LayoutEditor.Controls
                         if (SequencerButton(draw_list, buttonPos, 'S', isFocused, 0xff69992f) && canMouseClickOnRow)
                         {
                             Tooltip("Display only this animation");
-                            if (io.MouseDown[0])
+                            if (io.MouseReleased[0])
                             {
                                 if (isFocused)
                                     sequence.ResetFocus();
@@ -445,7 +445,7 @@ namespace OpenKh.Tools.LayoutEditor.Controls
                         if (SequencerButton(draw_list, buttonPos, 'D', false, ColorWhite) && canMouseClickOnRow)
                         {
                             Tooltip("Duplicate animation");
-                            if (io.MouseDown[0])
+                            if (io.MouseReleased[0])
                                 duplicateAnimationEntry = i;
                         }
 
@@ -453,7 +453,7 @@ namespace OpenKh.Tools.LayoutEditor.Controls
                         if (SequencerButton(draw_list, buttonPos, 'R', false, ColorWhite) && canMouseClickOnRow)
                         {
                             Tooltip("Remove animation");
-                            if (io.MouseDown[0])
+                            if (io.MouseReleased[0])
                                 deleteAnimationEntry = i;
                         }
                     }


### PR DESCRIPTION
- [x] "Show at frame" input box was writing the wrong value.
- [x] Timeline items can be clickable even when a pop-up window is in front of them.
- [x] Timeline buttons are clicked continuously.
- [x] Unable to assign sprites to a new animation.