### PR TITLE
Add simple file mod support

### DIFF
--- a/OpenKh.Game/Config.cs
+++ b/OpenKh.Game/Config.cs
@@ -16,6 +16,7 @@ namespace OpenKh.Game
             public float resolutionBoost { get; set; } = 2.0f;
             public bool isFullScreen { get; set; } = false;
             public string dataPath { get; set; } = "./data";
+            public string modPath { get; set; } = "./mod";
             public int regionId { get; set; } = -1;
             public bool enforceInternationalTextEncoding { get; set; } = false;
             public string idxFilePath { get; set; } = "KH2.IDX";
@@ -53,6 +54,7 @@ namespace OpenKh.Game
         public static float ResolutionBoost { get => _config.resolutionBoost; set => _config.resolutionBoost = value; }
         public static bool IsFullScreen { get => _config.isFullScreen; set => _config.isFullScreen = value; }
         public static string DataPath { get => _config.dataPath; set => _config.dataPath = value; }
+        public static string ModPath { get => _config.modPath; set => _config.modPath = value; }
         public static int RegionId { get => _config.regionId; set => _config.regionId = value; }
         public static bool EnforceInternationalTextEncoding { get => _config.enforceInternationalTextEncoding; set => _config.enforceInternationalTextEncoding = value; }
         public static string IdxFilePath { get => _config.idxFilePath; set => _config.idxFilePath = value; }

--- a/OpenKh.Game/DataContent/ModDataContent.cs
+++ b/OpenKh.Game/DataContent/ModDataContent.cs
@@ -1,0 +1,25 @@
+﻿using OpenKh.Game.Debugging;
+using OpenKh.Game.Infrastructure;
+using System.IO;
+
+namespace OpenKh.Game.DataContent
+{
+    public class ModDataContent : IDataContent
+    {
+        public bool FileExists(string fileName) => File.Exists(GetPath(fileName));
+
+        public Stream FileOpen(string path)
+        {
+            var fileName = GetPath(path);
+            if (File.Exists(fileName))
+            {
+                Log.Info($"Load mod {path}");
+                return File.OpenRead(fileName);
+            }
+
+            return null;
+        }
+
+        private string GetPath(string path) => Path.Combine(Config.ModPath, path);
+    }
+}

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -57,6 +57,7 @@ namespace OpenKh.Game
             var contentPath = args.FirstOrDefault() ?? Config.DataPath;
 
             _dataContent = CreateDataContent(contentPath, Config.IdxFilePath, Config.ImgFilePath);
+            _dataContent = new MultipleDataContent(new ModDataContent(), _dataContent);
             if (Kernel.IsReMixFileHasHdAssetHeader(_dataContent, "fm"))
             {
                 Log.Info("ReMIX files with HD asset header detected");


### PR DESCRIPTION
This is a quick one. I often found that when I wanted to test modded asset on OpenKH game engine, I had to modify the original game files and often accidentally losing the source.
This adds mod support. By default it tries to find files in the `mod` folder. If the file is found, it loads the modded one. If it is not, it is going to fall back to the original file.

Of course you can set any path from the `config.yml`. I personally set the VFS of CC's DynamicLoader.