### PR TITLE
Fix formatting on msn.md

### DIFF
--- a/docs/kh2/file/type/msn.md
+++ b/docs/kh2/file/type/msn.md
@@ -12,19 +12,19 @@ How this file is read is not completely understood.
 
 What is known about this file is as follows:
 
-| Offset | Type   | Description
-|-|-|-
-| 0x00 | uint16 | Magic Code, always `2`
-| 0x02 | BitArray | Boolean Flag Array [1]
-| 0x03 | BitArray  | Boolean Flag Array [2]
-| 0x04 | BitArray | Boolean Flag Array [3]
-| 0x05 | BitArray | Boolean Flag Array [4]
-| 0x06 | uint16 | Unknown. Probably actually a bit array.
-| 0x08 | Unknown (Either uint16 or BitArray) | Pause Menu Controller
-| 0x0A | uint16 | Pause Menu Information Text
-| 0x0C | BitArray | Boolean Flag Array [5]
-| 0x0D | BitArray | Boolean Flag Array [6]
-| 0x0E | uint16 | Antiform Multiplier
+| Offset | Type   | Description |
+|--------|--------|-------------|
+| 0x00   | uint16 | Magic Code, always `2`
+| 0x02   | BitArray | Boolean Flag Array [1]
+| 0x03   | BitArray | Boolean Flag Array [2]
+| 0x04   | BitArray | Boolean Flag Array [3]
+| 0x05   | BitArray | Boolean Flag Array [4]
+| 0x06   | uint16 | Unknown. Probably actually a bit array.
+| 0x08   | Unknown (Either uint16 or BitArray) | Pause Menu Controller
+| 0x0A   | uint16 | Pause Menu Information Text
+| 0x0C   | BitArray | Boolean Flag Array [5]
+| 0x0D   | BitArray | Boolean Flag Array [6]
+| 0x0E   | uint16 | Antiform Multiplier
 | - | - | -
 | 0x1C | uint16 | Intro Camera Controller
 
@@ -34,8 +34,8 @@ What is known about this file is as follows:
 This file uses Bit Arrays to store boolean flags for use during the missions. Known arrays/flags are as follows:
 
 #### Boolean Flag Array 3
-| Bit | Description
-|-|-
+| Bit | Description |
+|-----|-------------|
 | 1 | Is Boss Battle?
 | 2 | Is Drive Disabled?
 | 4 | ???
@@ -46,8 +46,8 @@ This file uses Bit Arrays to store boolean flags for use during the missions. Kn
 | 128 | ???
 
 #### Boolean Flag Array 4
-| Bit | Description
-|-|-
+| Bit | Description |
+|-----|-------------|
 | 1 | ???
 | 2 | Can Mickey save Sora?
 | 4 | ???
@@ -60,28 +60,28 @@ This file uses Bit Arrays to store boolean flags for use during the missions. Kn
 ### Pause Menu Controller
 Defines the type of Pause Menu Available when pressing start. Known values are as follows:
 
-| Value | Description
-| - | -
+| Value | Description |
+|-------|-------------|
 | 00 | Only pause menu
-|01 | Only pause menu
-|02 | 4 button pause menu with text (cont, retry, help, quit)
-|03 | Only pause menu
-|04 | Only pause menu
-|05 | Pause menu with text
-|06 | Pause menu with text
-|07 | Only pause menu
-|08 | 3 button pause menu (retry, help, quit)
-|09 | Jiminy's journal
-|0A | Only pause menu
-|0B | Only pause menu
-|0C | Only pause menu
-|0D | Only pause menu
-|0E | Only pause menu
-|0F | Only pause menu
-|-|-
-|1C| Pause Menu with Text and 3 Options (Continue, Jiminy's Journal, Save)
-|1E| Pause Menu with Text and 4 Options (Continue, Retry, Help, Quit)
-|1F| ???
+| 01 | Only pause menu
+| 02 | 4 button pause menu with text (cont, retry, help, quit)
+| 03 | Only pause menu
+| 04 | Only pause menu
+| 05 | Pause menu with text
+| 06 | Pause menu with text
+| 07 | Only pause menu
+| 08 | 3 button pause menu (retry, help, quit)
+| 09 | Jiminy's journal
+| 0A | Only pause menu
+| 0B | Only pause menu
+| 0C | Only pause menu
+| 0D | Only pause menu
+| 0E | Only pause menu
+| 0F | Only pause menu
+| -|-
+| 1C | Pause Menu with Text and 3 Options (Continue, Jiminy's Journal, Save)
+| 1E | Pause Menu with Text and 4 Options (Continue, Retry, Help, Quit)
+| 1F | ???
 
 This is most likely a BitArray and needs to be explored further.
 

--- a/docs/kh2/file/type/msn.md
+++ b/docs/kh2/file/type/msn.md
@@ -23,7 +23,7 @@ What is known about this file is as follows:
 | 0x08   | Unknown (Either uint16 or BitArray) | Pause Menu Controller
 | 0x0A   | uint16 | Pause Menu Information Text
 | 0x0C   | BitArray | Boolean Flag Array [5]
-| 0x0D   | BitArray | Boolean Flag Array [6]
+| 0x0D   | byte | [Bonus Reward](00battle.md#bons)
 | 0x0E   | uint16 | Antiform Multiplier
 | - | - | -
 | 0x1C | uint16 | Intro Camera Controller


### PR DESCRIPTION
Some tables weren't rendered properly on openkh.dev
Additionally, i've changed the definition of pos 0xD, as it's holds the bonus reward.

![grafik](https://user-images.githubusercontent.com/29046361/89128605-1b678080-d4f7-11ea-8100-a561e4ac13e4.png)
