### PR TITLE
Fix crash for TextEditor when '{:clear }' was supposed to be draw

### DIFF
--- a/OpenKh.Tools.Common/Rendering/SpriteDrawingDirect3D.Drawing.cs
+++ b/OpenKh.Tools.Common/Rendering/SpriteDrawingDirect3D.Drawing.cs
@@ -53,7 +53,7 @@ namespace OpenKh.Tools.Common.Rendering
 
         public void AppendSprite(SpriteDrawingContext context)
         {
-            SetTextureToDraw(context.SpriteTexture);
+            SetTextureToDraw(context.SpriteTexture ?? _defaultTexture);
             var width = _currentTexture.Width;
             var height = _currentTexture.Height;
             var viewport = _viewportSize;


### PR DESCRIPTION
Very clear from the title. It was preventing to use the editor in certain scenario.