### PR TITLE
OpenKh.Command.ImgTool swizzle-on support for imd/imz

### DIFF
--- a/OpenKh.Command.ImgTool/Program.cs
+++ b/OpenKh.Command.ImgTool/Program.cs
@@ -153,6 +153,9 @@ namespace OpenKh.Command.ImgTool
             [Option(CommandOptionType.NoValue, Description = "Use embedded nQuant.Core color quantizer. This is default selection.", ShortName = "n", LongName = "nquant")]
             public bool nQuant { get; set; }
 
+            [Option(CommandOptionType.NoValue, Description = "Enable swizzle.", ShortName = "s", LongName = "swizzle")]
+            public bool Swizzle { get; set; }
+
             protected int OnExecute(CommandLineApplication app)
             {
                 var inputFile = PngFile;
@@ -163,7 +166,7 @@ namespace OpenKh.Command.ImgTool
                 // Alpha enabled png → always 32 bpp
                 using (var bitmap = new Bitmap(inputFile))
                 {
-                    var imgd = ImgdBitmapUtil.ToImgd(bitmap, BitsPerPixel, QuantizerFactory.MakeFrom(this));
+                    var imgd = ImgdBitmapUtil.ToImgd(bitmap, BitsPerPixel, QuantizerFactory.MakeFrom(this), Swizzle);
 
                     var buffer = new MemoryStream();
                     imgd.Write(buffer);
@@ -196,6 +199,9 @@ namespace OpenKh.Command.ImgTool
             [Option(CommandOptionType.NoValue, Description = "Try to append to imz", ShortName = "a", LongName = "append")]
             public bool Append { get; set; }
 
+            [Option(CommandOptionType.NoValue, Description = "Enable swizzle for png input.", ShortName = "s", LongName = "swizzle")]
+            public bool Swizzle { get; set; }
+
             protected int OnExecute(CommandLineApplication app)
             {
                 OutputImz = OutputImz ?? Path.GetFullPath(Path.GetFileName(Path.ChangeExtension(InputFile.First(), ".imz")));
@@ -212,7 +218,7 @@ namespace OpenKh.Command.ImgTool
                     prependImgdList
                         .Concat(
                             InputFile
-                                .SelectMany(imdFile => ImgdBitmapUtil.FromFileToImgdList(imdFile, BitsPerPixel, QuantizerFactory.MakeFrom(this)))
+                                .SelectMany(imdFile => ImgdBitmapUtil.FromFileToImgdList(imdFile, BitsPerPixel, QuantizerFactory.MakeFrom(this), Swizzle))
                         )
                         .ToArray()
                 );

--- a/OpenKh.Command.ImgTool/Utils/ImgdBitmapUtil.cs
+++ b/OpenKh.Command.ImgTool/Utils/ImgdBitmapUtil.cs
@@ -196,7 +196,7 @@ namespace OpenKh.Kh2.Utils
             }
         }
 
-        public static Imgd ToImgd(Bitmap bitmap, int bpp, Func<Bitmap, Bitmap> quantizer)
+        public static Imgd ToImgd(Bitmap bitmap, int bpp, Func<Bitmap, Bitmap> quantizer, bool swizzle = false)
         {
             if (quantizer != null)
             {
@@ -254,7 +254,7 @@ namespace OpenKh.Kh2.Utils
                             }
                         }
 
-                        return Imgd.Create(bitmap.Size, Imaging.PixelFormat.Indexed4, destBits, clut, false);
+                        return Imgd.Create(bitmap.Size, Imaging.PixelFormat.Indexed4, destBits, clut, swizzle);
                     }
                 case 8:
                     {
@@ -295,7 +295,7 @@ namespace OpenKh.Kh2.Utils
                             }
                         }
 
-                        return Imgd.Create(bitmap.Size, Imaging.PixelFormat.Indexed8, destBits, clut, false);
+                        return Imgd.Create(bitmap.Size, Imaging.PixelFormat.Indexed8, destBits, clut, swizzle);
                     }
                 case 32:
                     {
@@ -321,19 +321,19 @@ namespace OpenKh.Kh2.Utils
                             }
                         }
 
-                        return Imgd.Create(bitmap.Size, Imaging.PixelFormat.Rgba8888, destBits, new byte[0], false);
+                        return Imgd.Create(bitmap.Size, Imaging.PixelFormat.Rgba8888, destBits, new byte[0], swizzle);
                     }
             }
             throw new NotSupportedException($"BitsPerPixel {bpp} not recognized!");
         }
 
-        public static IEnumerable<Imgd> FromFileToImgdList(string anyFile, int bitsPerPixel, Func<Bitmap, Bitmap> quantizer)
+        public static IEnumerable<Imgd> FromFileToImgdList(string anyFile, int bitsPerPixel, Func<Bitmap, Bitmap> quantizer, bool swizzle)
         {
             switch (Path.GetExtension(anyFile).ToLowerInvariant())
             {
                 case ".png":
                     {
-                        yield return new Bitmap(anyFile).Using(bitmap => ToImgd(bitmap, bitsPerPixel, quantizer));
+                        yield return new Bitmap(anyFile).Using(bitmap => ToImgd(bitmap, bitsPerPixel, quantizer, swizzle));
                         break;
                     }
                 case ".imd":


### PR DESCRIPTION
Adding command line option `-s|--swizzle` to activate swizzle on ImgTool.

```bat
H>OpenKh.Command.ImgTool.exe imd -h
png file -> imd file

Usage: OpenKh.Command.ImgTool imd [options] <PngFile>

Arguments:
  PngFile                    Input png

Options:
  -?|-h|--help               Show help information
  -o|--output <OUTPUT_IMD>   Output imd. Default is current dir, and file extension to imd.
  -b|--bpp <BITS_PER_PIXEL>  Set bits per pixel: 4, 8, or 32
  -p|--pngquant              Use `pngquant.exe` -- lossy PNG compressor. Download `pngquant.exe` and place it beside
                             this program, current directory, or PATH.
  -n|--nquant                Use embedded nQuant.Core color quantizer. This is default selection.
  -s|--swizzle               Enable swizzle.


H>OpenKh.Command.ImgTool.exe imz -h
png, imd or imz files -> imz file

Usage: OpenKh.Command.ImgTool imz [options]

Options:
  -?|-h|--help               Show help information
  -i|--input <INPUT_FILE>    Input png/imd/imz file
  -o|--output <OUTPUT_IMZ>   Output imz file. Default is current dir, and first file extension to imz.
  -b|--bpp <BITS_PER_PIXEL>  Set bits per pixel for every png: 4, 8, or 32
  -p|--pngquant              Use `pngquant.exe` -- lossy PNG compressor. Download `pngquant.exe` and deploy it beside
                             this program, current directory, or PATH.
  -n|--nquant                Use embedded nQuant.Core color quantizer. This is default selection.
  -a|--append                Try to append to imz
  -s|--swizzle               Enable swizzle for png input.
```