### PR TITLE
Small fix to ImgTool: prevent pngquant from blocking

### DIFF
--- a/OpenKh.Command.ImgTool/Utils/QuantizerFactory.cs
+++ b/OpenKh.Command.ImgTool/Utils/QuantizerFactory.cs
@@ -30,7 +30,7 @@ namespace OpenKh.Command.ImgTool.Utils
                                     RedirectStandardInput = true,
                                     RedirectStandardOutput = true,
                                 };
-                                var p = Process.Start(psi);
+                                using var p = Process.Start(psi);
                                 using (var temp = new MemoryStream())
                                 {
                                     bitmap.Save(temp, ImageFormat.Png);

--- a/OpenKh.Command.ImgTool/Utils/QuantizerFactory.cs
+++ b/OpenKh.Command.ImgTool/Utils/QuantizerFactory.cs
@@ -36,6 +36,7 @@ namespace OpenKh.Command.ImgTool.Utils
                                     bitmap.Save(temp, ImageFormat.Png);
                                     temp.Position = 0;
                                     temp.CopyTo(p.StandardInput.BaseStream);
+                                    p.StandardInput.BaseStream.Close(); // prevent pngquant from blocking.
                                 }
                                 var newBitmap = new Bitmap(p.StandardOutput.BaseStream);
                                 return newBitmap;


### PR DESCRIPTION
Sometimes ImgTool hanged up on conversion from png to imgd, when enabling pngquant.
This pull request fixes potential problem by closing stdin of pngquant process.