### PR TITLE
MapGen: Copy COCT data to DOCT, and roughen COCT resolution

### DIFF
--- a/OpenKh.Command.DoctChanger/Program.cs
+++ b/OpenKh.Command.DoctChanger/Program.cs
@@ -306,8 +306,8 @@ namespace OpenKh.Command.DoctChanger
 
             private void PrintSummary(Doct coct)
             {
-                Console.WriteLine($"{coct.Entry1List.Count,8:#,##0} collision mesh groups.");
-                Console.WriteLine($"{coct.Entry2List.Count,8:#,##0} collision meshes.");
+                Console.WriteLine($"{coct.Entry1List.Count,8:#,##0} drawing mesh groups.");
+                Console.WriteLine($"{coct.Entry2List.Count,8:#,##0} drawing meshes.");
             }
         }
     }

--- a/OpenKh.Command.MapGen/Models/BigMesh.cs
+++ b/OpenKh.Command.MapGen/Models/BigMesh.cs
@@ -27,6 +27,8 @@ namespace OpenKh.Command.MapGen.Models
 
         public MaterialDef matDef;
 
+        public List<ushort> vifPacketIndices = new List<ushort>();
+
         public class TriangleStrip
         {
             public List<int> vertexIndices = new List<int>();

--- a/OpenKh.Command.MapGen/Models/MapGenConfig.cs
+++ b/OpenKh.Command.MapGen/Models/MapGenConfig.cs
@@ -73,6 +73,8 @@ namespace OpenKh.Command.MapGen.Models
 
         public byte? maxAlpha { get; set; }
 
+        public bool reuseImd { get; set; }
+
         public MaterialDef FindMaterial(string name)
         {
             return materials

--- a/OpenKh.Command.MapGen/Models/MaterialDef.cs
+++ b/OpenKh.Command.MapGen/Models/MaterialDef.cs
@@ -23,9 +23,14 @@ namespace OpenKh.Command.MapGen.Models
         public string fromFile { get; set; }
 
         /// <summary>
-        /// texture from png file (diffuse map with texture file source)
+        /// use if reuseImd: Path.ChangeExtension(fromFile3, ".imd")
         /// </summary>
         public string fromFile2 { get; set; }
+
+        /// <summary>
+        /// texture from png file (diffuse map with texture file source)
+        /// </summary>
+        public string fromFile3 { get; set; }
 
         /// <summary>
         /// Have not collision

--- a/OpenKh.Command.MapGen/Program.cs
+++ b/OpenKh.Command.MapGen/Program.cs
@@ -243,6 +243,7 @@ namespace OpenKh.Command.MapGen
                 var fileNames = new string[] {
                     matDef.fromFile,
                     matDef.fromFile2,
+                    matDef.fromFile3,
                     matDef.name + ".imd",
                     matDef.name + ".png",
                 }

--- a/OpenKh.Kh2/Doct.cs
+++ b/OpenKh.Kh2/Doct.cs
@@ -155,9 +155,81 @@ namespace OpenKh.Kh2
                 it.Entry2LastIndex - it.Entry2Index
             )
                 .Select(index => Entry2List[index].BoundingBox)
+                .Concat(SelectBoundingBoxList(it))
                 .MergeAll();
 
             return it;
+        }
+
+        private IEnumerable<BoundingBox> SelectBoundingBoxList(Entry1 ent1)
+        {
+            if (ent1.Child1 != -1)
+            {
+                yield return Entry1List[ent1.Child1].BoundingBox;
+
+                if (ent1.Child2 != -1)
+                {
+                    yield return Entry1List[ent1.Child2].BoundingBox;
+
+                    if (ent1.Child3 != -1)
+                    {
+                        yield return Entry1List[ent1.Child3].BoundingBox;
+
+                        if (ent1.Child4 != -1)
+                        {
+                            yield return Entry1List[ent1.Child4].BoundingBox;
+
+                            if (ent1.Child5 != -1)
+                            {
+                                yield return Entry1List[ent1.Child5].BoundingBox;
+
+                                if (ent1.Child6 != -1)
+                                {
+                                    yield return Entry1List[ent1.Child6].BoundingBox;
+
+                                    if (ent1.Child7 != -1)
+                                    {
+                                        yield return Entry1List[ent1.Child7].BoundingBox;
+
+                                        if (ent1.Child8 != -1)
+                                        {
+                                            yield return Entry1List[ent1.Child8].BoundingBox;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public void ReverseEntry1()
+        {
+            var maxIndex = Entry1List.Count - 1;
+
+            Entry1List.Reverse();
+
+            short ReverseChildIndex(short child)
+            {
+                if (child != -1)
+                {
+                    child = Convert.ToInt16(maxIndex - child);
+                }
+                return child;
+            }
+
+            foreach (var one in Entry1List)
+            {
+                one.Child1 = ReverseChildIndex(one.Child1);
+                one.Child2 = ReverseChildIndex(one.Child2);
+                one.Child3 = ReverseChildIndex(one.Child3);
+                one.Child4 = ReverseChildIndex(one.Child4);
+                one.Child5 = ReverseChildIndex(one.Child5);
+                one.Child6 = ReverseChildIndex(one.Child6);
+                one.Child7 = ReverseChildIndex(one.Child7);
+                one.Child8 = ReverseChildIndex(one.Child8);
+            }
         }
     }
 }

--- a/docs/tool/CLI.CoctChanger/index.md
+++ b/docs/tool/CLI.CoctChanger/index.md
@@ -63,3 +63,38 @@ OpenKh.Command.CoctChanger.exe use-this-coct C:\A\eh18 H:\Proj\pcsx2\bin\inject.
 
 C:\A\eh18\eh18.map
 ```
+
+### `show-stats` command
+
+Specify: `.map` file, otherwise treated as `.coct` file.
+
+```bat
+OpenKh.Command.CoctChanger.exe show-stats tt05.map
+
+# ID_t:0 (MapCollision)
+     352 collision mesh groups.
+     306 collision meshes.
+   1,076 collisions.
+   1,968 vertices.
+     869 planes.
+     943 bounding boxes.
+      11 surface flags.
+
+# CH_t:0 (CameraCollision)
+     205 collision mesh groups.
+     151 collision meshes.
+     250 collisions.
+     492 vertices.
+     236 planes.
+     151 bounding boxes.
+       3 surface flags.
+
+# COL_:0 (LightData)
+      55 collision mesh groups.
+      33 collision meshes.
+      41 collisions.
+     114 vertices.
+      17 planes.
+      14 bounding boxes.
+       1 surface flags.
+```

--- a/docs/tool/CLI.DoctChanger/index.md
+++ b/docs/tool/CLI.DoctChanger/index.md
@@ -136,3 +136,15 @@ OpenKh.Command.DoctChanger.exe read-map-doct H:\Proj\pcsx2\bin\inject.f266b00b\m
  724:00000000 (  -18000,  -18000,  -18000) (   18000,   18000,   18000)
 '''
 ```
+
+### `show-stats` command
+
+Specify: `.map` file, otherwise treated as `.doct` file.
+
+```bat
+OpenKh.Command.DoctChanger.exe show-stats tt05.map
+
+# tt_0:0 (MeshOcclusion)
+   1,320 drawing mesh groups.
+   1,330 drawing meshes.
+```

--- a/docs/tool/CLI.MapGen/index.md
+++ b/docs/tool/CLI.MapGen/index.md
@@ -252,6 +252,21 @@ maxAlpha: 128
   transparentFlag: 0
 ```
 
+### skipConversionIfExists
+
+```yml
+# Specify true if you want to skip png to imd conversion.
+skipConversionIfExists: true
+```
+
+### reuseImd
+
+```yml
+# Specify true if you want to reuse `.imd` file converted by ImgTool.
+# This is useful if diffuse texture file path is `images/tex.png`, and omit re-conversion.
+reuseImd: true
+```
+
 ### bar
 
 ```yml
@@ -321,7 +336,8 @@ eachInputDir:
 eachFileName:
 
 - `fromFile` of material (you can specify)
-- `fromFile2` of material (extracted from material's diffuse texture file path)
+- `fromFile2` of material (extracted from material's diffuse texture file path as imd extension, if reuseImd set)
+- `fromFile3` of material (extracted from material's diffuse texture file path)
 - material name + ".imd"
 - material name + ".png"
 


### PR DESCRIPTION
## MapGen improvements

Copy COCT data to DOCT:

- Use COCT data to create DOCT data.
- Usually KH2 asset maps use different data for COCT/DOCT.

Roughen COCT resolution:

- COCT and DOCT data basically needs "recursive call".
- Currently COCT data has deep depth. About COCT processing it has no problem. About DOCT processing it has rendering problem. So try to roughen COCT for example, and lower splitter resolution.

## CoctChanger `show-stats` command

Visualize COCT data quantity in numerical form.

```txt
H>OpenKh.Command.CoctChanger.exe show-stats H:\KH2fm.OpenKH\map\jp\tt05.map
# ID_t:0 (MapCollision)
     352 collision mesh groups.
     306 collision meshes.
   1,076 collisions.
   1,968 vertices.
     869 planes.
     943 bounding boxes.
      11 surface flags.

# CH_t:0 (CameraCollision)
     205 collision mesh groups.
     151 collision meshes.
     250 collisions.
     492 vertices.
     236 planes.
     151 bounding boxes.
       3 surface flags.

# COL_:0 (LightData)
      55 collision mesh groups.
      33 collision meshes.
      41 collisions.
     114 vertices.
      17 planes.
      14 bounding boxes.
       1 surface flags.
```

Before MapGen fix:

```
H>OpenKh.Command.CoctChanger.exe show-stats H:\Dev\KH2\Disgustor\map_test\di00_01.map

# ID_e:0 (MapCollision)
   5,342 collision mesh groups.
   2,671 collision meshes.
  30,339 collisions.
  23,231 vertices.
  25,514 planes.
  26,846 bounding boxes.
       1 surface flags.
```

After MapGen fix:

```txt
H>OpenKh.Command.CoctChanger.exe show-stats H:\Dev\KH2\Disgustor\map_test\di00_01.map

# ID_e:0 (MapCollision)
     252 collision mesh groups.
     126 collision meshes.
  30,339 collisions.
  23,231 vertices.
  25,606 planes.
  26,846 bounding boxes.
       1 surface flags.
```

## DoctChanger `show-stats` command

Visualize DOCT data quantity in numerical form.

```txt
H>OpenKh.Command.DoctChanger.exe show-stats H:\KH2fm.OpenKH\map\jp\tt05.map

# tt_0:0 (MeshOcclusion)
   1,320 drawing mesh groups.
   1,330 drawing meshes.
```

Before MapGen fix:

```txt
H>OpenKh.Command.DoctChanger.exe show-stats H:\Dev\KH2\Disgustor\map_test\di00_01.map

# eh_1:0 (MeshOcclusion)
       1 drawing mesh groups.
       1 drawing meshes.
```

After MapGen fix:

```txt
H>OpenKh.Command.DoctChanger.exe show-stats H:\Dev\KH2\Disgustor\map_test\di00_01.map
# eh_1:0 (MeshOcclusion)
     252 drawing mesh groups.
     126 drawing meshes.
```
