### PR TITLE
ImgTool alpha issue fix

### DIFF
--- a/OpenKh.Command.ImgTool/Utils/ImgdBitmapUtil.cs
+++ b/OpenKh.Command.ImgTool/Utils/ImgdBitmapUtil.cs
@@ -147,6 +147,16 @@ namespace OpenKh.Kh2.Utils
             public int Height { get; }
         }
 
+        static class PaletteColorUsageCounter
+        {
+            public static bool IfMaxColorCountIsOver(List<uint> pixels, int maxColors)
+            {
+                return pixels
+                    .GroupBy(pixel => pixel)
+                    .Count() > maxColors;
+            }
+        }
+
         class PaletteGenerator
         {
             public PaletteGenerator(List<uint> pixels, int maxColors)
@@ -200,7 +210,12 @@ namespace OpenKh.Kh2.Utils
         {
             if (quantizer != null)
             {
-                bitmap = quantizer(bitmap);
+                var firstSrc = new ReadAs32bppPixels(bitmap);
+
+                if (PaletteColorUsageCounter.IfMaxColorCountIsOver(firstSrc.Pixels, 1 << bpp))
+                {
+                    bitmap = quantizer(bitmap);
+                }
             }
 
             switch (bpp)

--- a/OpenKh.Command.ImgTool/Utils/QuantizerFactory.cs
+++ b/OpenKh.Command.ImgTool/Utils/QuantizerFactory.cs
@@ -45,8 +45,8 @@ namespace OpenKh.Command.ImgTool.Utils
                             {
                                 return (Bitmap)new WuQuantizer().QuantizeImage(
                                     new Bitmap(bitmap), // make sure it is 32 bpp, not 24 bpp
-                                    alphaThreshold: 10, // default
-                                    alphaFader: 70, // default
+                                    alphaThreshold: -1, // default
+                                    alphaFader: 1, // default
                                     maxColors
                                 );
                                 // I believe that nQuant never throws exception.

--- a/OpenKh.Command.ImgTool/Utils/QuantizerFactory.cs
+++ b/OpenKh.Command.ImgTool/Utils/QuantizerFactory.cs
@@ -45,8 +45,8 @@ namespace OpenKh.Command.ImgTool.Utils
                             {
                                 return (Bitmap)new WuQuantizer().QuantizeImage(
                                     new Bitmap(bitmap), // make sure it is 32 bpp, not 24 bpp
-                                    alphaThreshold: -1, // default
-                                    alphaFader: 1, // default
+                                    alphaThreshold: -1,
+                                    alphaFader: 1,
                                     maxColors
                                 );
                                 // I believe that nQuant never throws exception.


### PR DESCRIPTION
Two fixes:

(1) Loose of transparent color.

Original (export from KH1)

![2020-08-08_11h51_56](https://user-images.githubusercontent.com/5955540/89700937-9c969b80-d96d-11ea-9beb-dd9a57bb17d8.png)

Converted with ImgTool (nQuant). Loosing transparent color.

![2020-08-08_11h51_48](https://user-images.githubusercontent.com/5955540/89700938-9e605f00-d96d-11ea-957b-4be623cd2391.png)

Converted with ImgTool (nQuant). Holding transparent color.

![2020-08-08_11h52_13](https://user-images.githubusercontent.com/5955540/89700939-a0c2b900-d96d-11ea-931f-b5c8c7af4fe9.png)

(2) flatting image color palette

Original imd → png

![2020-08-08_11h50_46](https://user-images.githubusercontent.com/5955540/89700984-01ea8c80-d96e-11ea-8630-05c0be80f00a.png)

Converted with ImgTool (nQuant). Loosing detail of color intensity.

![2020-08-08_11h50_40](https://user-images.githubusercontent.com/5955540/89700987-0616aa00-d96e-11ea-976b-8c269420cd26.png)

Converted with ImgTool (nQuant). Keep color intensity.

![2020-08-08_11h51_00](https://user-images.githubusercontent.com/5955540/89700988-0747d700-d96e-11ea-8d03-d09010fea555.png)

PS. Another sample using quantization

png:

![2020-08-08_11h49_37](https://user-images.githubusercontent.com/5955540/89701059-b08ecd00-d96e-11ea-8bb7-0fc1bdd30504.png)

Converted with ImgTool (nQuant). Alpha channel looks good.

![2020-08-08_11h49_28](https://user-images.githubusercontent.com/5955540/89701058-ae2c7300-d96e-11ea-95e2-7af31d397ecc.png)


Technically:

(1) Do not apply quantization if not required. (e.g. 8-bpp image with simultaneously palette color count usage less or equal than 256)

(2) Tweak nQuant parameter: `alphaThreshold: -1` and `alphaFader: 1,`
