### PR TITLE
Fix sequence interpolation

### DIFF
--- a/OpenKh.Engine/Renders/SequenceRenderer.cs
+++ b/OpenKh.Engine/Renders/SequenceRenderer.cs
@@ -137,7 +137,7 @@ namespace OpenKh.Engine.Renderers
 
         private void DrawAnimation(Context contextParent, Sequence.Animation animation, int index)
         {
-            // 0000 0001 = (0 = CUBIC INTERPOLATION, 1 = LINEAR INTERPOLATION)
+            // 0000 0001 = (0 = EASE IN/OUT INTERPOLATION, 1 = LINEAR INTERPOLATION)
             // 0000 0008 = (0 = BOUNCING START FROM CENTER, 1 = BOUNCING START FROM X / MOVE FROM Y)
             // 0000 0010 = (0 = ENABLE BOUNCING, 1 = IGNORE BOUNCING)
             // 0000 0020 = (0 = ENABLE ROTATION, 1 = IGNORE ROTATION)

--- a/OpenKh.Engine/Renders/SequenceRenderer.cs
+++ b/OpenKh.Engine/Renders/SequenceRenderer.cs
@@ -158,7 +158,7 @@ namespace OpenKh.Engine.Renderers
             if ((animation.Flags & Sequence.LinearInterpolationFlag) != 0)
                 t = (float)delta;
             else
-                t = (float)(delta * delta * delta);
+                t = (float)((Math.Sin(delta * Math.PI - Math.PI / 2.0) + 1.0) / 2.0);
 
             context.PositionX += Lerp(t, animation.TranslateXStart, animation.TranslateXEnd);
             context.PositionY += Lerp(t, animation.TranslateYStart, animation.TranslateYEnd);

--- a/OpenKh.Tests/Engine/SequenceRendererTest.cs
+++ b/OpenKh.Tests/Engine/SequenceRendererTest.cs
@@ -19,8 +19,8 @@ namespace OpenKh.Tests.Engine
         [InlineData(0, 0, 0, 0, 0)]
         [InlineData(0, 1000, 1, 0, 0)]
         [InlineData(0, 1000, 1, 500, 500)]
-        [InlineData(0, 1000, 0, 500, 125)]
-        [InlineData(0, 1000, 0, 750, 422)]
+        [InlineData(0, 1000, 0, 500, 500)]
+        [InlineData(0, 1000, 0, 750, 854)]
         public void TraslateXAnimationTest(int x0, int x1, int flags, int frameIndex, float expected)
         {
             var sequence = MockSequence(new Sequence.Animation
@@ -54,8 +54,8 @@ namespace OpenKh.Tests.Engine
         [InlineData(0, 0, 0, 0, 0)]
         [InlineData(0, 1000, 1, 0, 0)]
         [InlineData(0, 1000, 1, 500, 500)]
-        [InlineData(0, 1000, 0, 500, 125)]
-        [InlineData(0, 1000, 0, 750, 422)]
+        [InlineData(0, 1000, 0, 500, 500)]
+        [InlineData(0, 1000, 0, 750, 854)]
         [InlineData(0, 1000, 0x4000, 500, 0)]
         public void TraslateXBAnimationTest(int x0, int x1, int flags, int frameIndex, float expected)
         {

--- a/OpenKh.Tests/Engine/SequenceRendererTest.cs
+++ b/OpenKh.Tests/Engine/SequenceRendererTest.cs
@@ -114,7 +114,7 @@ namespace OpenKh.Tests.Engine
 
             AssertDraw(drawing, x =>
             {
-                Assert.Equal(419, x.Vec0.X, 0);
+                Assert.Equal(625, x.Vec0.X, 0);
             });
         }
 

--- a/OpenKh.Tools.LayoutEditor/AppSequenceEditor.cs
+++ b/OpenKh.Tools.LayoutEditor/AppSequenceEditor.cs
@@ -378,7 +378,7 @@ namespace OpenKh.Tools.LayoutEditor
 
             int interpolationMode = (animation.Flags & Sequence.LinearInterpolationFlag) != 0 ? 1 : 0;
             if (ImGui.Combo($"Interpolation##{index}", ref interpolationMode, new string[]
-                { "Cubic", "Linear" }, 2))
+                { "Ease in/out", "Linear" }, 2))
             {
                 var flag = Sequence.LinearInterpolationFlag;
                 animation.Flags = (animation.Flags & ~flag) | (interpolationMode == 0 ? 0 : flag);


### PR DESCRIPTION
I found we were using the wrong interpolation. It is not cubic, but it is an ease in-out interpolation, which have a slow start and end but a fast middle.

Before the fix:
![image](https://user-images.githubusercontent.com/6128729/90521643-151a0b00-e16b-11ea-9930-7c0dacdba433.png)

After the fix:
![image](https://user-images.githubusercontent.com/6128729/90521566-f9166980-e16a-11ea-905a-ac22b4cd1a5d.png)

---

Notice here how the fixed version fades out the "light" on the title screen quicker and the animations of NEW GAME and LOAD are way more accurate now:

Before the fix:
![unfix_1](https://user-images.githubusercontent.com/6128729/90520499-b1dba900-e169-11ea-8755-3b82d8e3093b.gif)

After the fix:
![fix_1](https://user-images.githubusercontent.com/6128729/90520420-9a042500-e169-11ea-9268-045d96b5e710.gif)

---

I noticed that the interpolation was wrong while I was developing the menu. I clearly remembered that the animation when you open the menu slows down when close to the end of the animation. This was definitively not happening before the fix, as the menu would instantly appear.

Before the fix:
![unfix_2](https://user-images.githubusercontent.com/6128729/90521307-b05eb080-e16a-11ea-81b0-34b059c17a72.gif)

After the fix:
![fix_2](https://user-images.githubusercontent.com/6128729/90521342-b5bbfb00-e16a-11ea-925f-75dc036cbc46.gif)
