### PR TITLE
KH2 IdxImg improvements

### DIFF
--- a/OpenKh.Command.IdxImg/Program.cs
+++ b/OpenKh.Command.IdxImg/Program.cs
@@ -80,6 +80,9 @@ namespace OpenKh.Command.IdxImg
             [Option(CommandOptionType.NoValue, Description = "Split sub-IDX when extracting recursively", ShortName = "s", LongName = "split")]
             public bool Split { get; set; }
 
+            [Option(CommandOptionType.NoValue, Description = "Do not extract files that are already found in the destination directory", ShortName = "n")]
+            public bool DoNotExtractAgain { get; set; }
+
             protected int OnExecute(CommandLineApplication app)
             {
                 var inputImg = InputImg ?? InputIdx.Replace(".idx", ".img", StringComparison.InvariantCultureIgnoreCase);
@@ -92,13 +95,21 @@ namespace OpenKh.Command.IdxImg
                     var img = new Img(imgStream, idxEntries, false);
                     var idxName = Path.GetFileNameWithoutExtension(InputIdx);
 
-                    var subIdxPath = ExtractIdx(img, idxEntries, Recursive && Split ? Path.Combine(outputDir, "KH2") : outputDir);
+                    var subIdxPath = ExtractIdx(
+                        img,
+                        idxEntries,
+                        Recursive && Split ? Path.Combine(outputDir, "KH2") : outputDir,
+                        DoNotExtractAgain);
                     if (Recursive)
                     {
                         foreach (var idxFileName in subIdxPath)
                         {
                             idxName = Path.GetFileNameWithoutExtension(idxFileName);
-                            ExtractIdx(img, OpenIdx(idxFileName), Split ? Path.Combine(outputDir, idxName) : outputDir);
+                            ExtractIdx(
+                                img,
+                                OpenIdx(idxFileName),
+                                Split ? Path.Combine(outputDir, idxName) : outputDir,
+                                DoNotExtractAgain);
                         }
                     }
                 }
@@ -106,7 +117,11 @@ namespace OpenKh.Command.IdxImg
                 return 0;
             }
 
-            public static List<string> ExtractIdx(Img img, IEnumerable<Idx.Entry> idxEntries, string basePath)
+            public static List<string> ExtractIdx(
+                Img img,
+                IEnumerable<Idx.Entry> idxEntries,
+                string basePath,
+                bool doNotExtractAgain)
             {
                 var idxs = new List<string>();
 
@@ -116,13 +131,15 @@ namespace OpenKh.Command.IdxImg
                     if (fileName == null)
                         fileName = $"@noname/{entry.Hash32:X08}-{entry.Hash16:X04}";
 
-                    Console.WriteLine(fileName);
-
                     var outputFile = Path.Combine(basePath, fileName);
+                    if (doNotExtractAgain && File.Exists(outputFile))
+                        continue;
+
                     var outputDir = Path.GetDirectoryName(outputFile);
                     if (Directory.Exists(outputDir) == false)
                         Directory.CreateDirectory(outputDir);
 
+                    Console.WriteLine(fileName);
                     using (var file = File.Create(outputFile))
                     {
                         // TODO handle decompression

--- a/OpenKh.Kh2/Img.cs
+++ b/OpenKh.Kh2/Img.cs
@@ -108,8 +108,10 @@ namespace OpenKh.Kh2
         {
             var srcIndex = srcData.Length - 1;
 
-            byte key;
-            while ((key = srcData[srcIndex--]) == 0) ;
+            byte key = 0;
+            while (srcIndex > 0 && (key = srcData[srcIndex--]) == 0) ;
+            if (srcIndex == 0)
+                return new byte[0];
 
             int decSize = srcData[srcIndex--] |
                 (srcData[srcIndex--] << 8) |

--- a/OpenKh.Tests/kh2/ImgTests.cs
+++ b/OpenKh.Tests/kh2/ImgTests.cs
@@ -74,6 +74,13 @@ namespace OpenKh.Tests.kh2
                     new MemoryStream(Img.Decompress(Img.Compress(inStream.ReadAllBytes()))));
             });
 
+        [Fact]
+        public void CreateEmptyFileIfCompressedSourceIsEmpty()
+        {
+            var input = Enumerable.Range(0, 0x1000).Select(_ => (byte)0).ToArray();
+            Assert.Empty(Img.Decompress(input));
+        }
+
         public void AlwaysCompressCorrectly()
         {
             using var imgStream = File.OpenRead("G:\\KH2.IMG");


### PR DESCRIPTION
Fix the following crash when a KH2.IMG can not be read correctly:
https://discordapp.com/channels/409140906625728532/567061704849096725/746662018010054727

Also implements #233 .