### PR TITLE
Rendering bug fixes for OpenKh.Game

### DIFF
--- a/OpenKh.Engine.MonoGame/KingdomShader.cs
+++ b/OpenKh.Engine.MonoGame/KingdomShader.cs
@@ -18,6 +18,7 @@ namespace OpenKh.Engine.MonoGame
         private readonly EffectParameter _parameterTextureWrapModeU;
         private readonly EffectParameter _parameterTextureWrapModeV;
         private readonly EffectParameter _parameterTexture0;
+        private readonly EffectParameter _parameterUseAlphaMask;
 
         public KingdomShader(ContentManager contentManager)
         {
@@ -30,6 +31,7 @@ namespace OpenKh.Engine.MonoGame
             _parameterTextureWrapModeU = Effect.Parameters["TextureWrapModeU"];
             _parameterTextureWrapModeV = Effect.Parameters["TextureWrapModeV"];
             _parameterTexture0 = Effect.Parameters["Texture0"];
+            _parameterUseAlphaMask = Effect.Parameters["UseAlphaMask"];
 
             ModelView = Matrix.Identity;
             WorldView = Matrix.Identity;
@@ -87,6 +89,12 @@ namespace OpenKh.Engine.MonoGame
         {
             get => (TextureWrapMode)_parameterTextureWrapModeV.GetValueInt32();
             set => _parameterTextureWrapModeV.SetValue((int)value);
+        }
+
+        public bool UseAlphaMask
+        {
+            get => _parameterUseAlphaMask.GetValueBoolean();
+            set => _parameterUseAlphaMask.SetValue(value);
         }
 
         public void Pass(Action<EffectPass> action)

--- a/OpenKh.Engine/Parsers/Kddf2/ImmutableMesh.cs
+++ b/OpenKh.Engine/Parsers/Kddf2/ImmutableMesh.cs
@@ -7,5 +7,6 @@ namespace OpenKh.Engine.Parsers.Kddf2
         public IndexAssignment[] indexAssignmentList = null;
         public VertexAssignment[][] vertexAssignmentsList = null;
         public int textureIndex = -1;
+        public bool isOpaque = true;
     }
 }

--- a/OpenKh.Engine/Parsers/Kddf2/Kkdf2MdlxBuiltModel.cs
+++ b/OpenKh.Engine/Parsers/Kddf2/Kkdf2MdlxBuiltModel.cs
@@ -6,7 +6,8 @@ namespace OpenKh.Engine.Parsers.Kddf2
 {
     public class Kkdf2MdlxBuiltModel
     {
-        public SortedDictionary<int, Model> textureIndexBasedModelDict;
+        // <textureIndex, isOpaque> -> Model
+        public SortedDictionary<Tuple<int, bool>, Model> textureIndexBasedModelDict;
         public Kkdf2MdlxParser parser;
     }
 }

--- a/OpenKh.Engine/Parsers/Kddf2/TriangleRef.cs
+++ b/OpenKh.Engine/Parsers/Kddf2/TriangleRef.cs
@@ -2,13 +2,15 @@
 {
     class TriangleRef
     {
-        public TriangleRef(int textureIndex, VertexRef one, VertexRef two, VertexRef three)
+        public TriangleRef(int textureIndex, bool isOpaque, VertexRef one, VertexRef two, VertexRef three)
         {
             this.textureIndex = textureIndex;
+            this.isOpaque = isOpaque;
             this.list = new VertexRef[] { one, two, three };
         }
 
         public VertexRef[] list;
         public int textureIndex;
+        public bool isOpaque;
     }
 }

--- a/OpenKh.Engine/Parsers/MdlxParser.cs
+++ b/OpenKh.Engine/Parsers/MdlxParser.cs
@@ -92,11 +92,8 @@ namespace OpenKh.Engine.Parsers
 
             var indexBuffer = new int[4];
             var recentIndex = 0;
-            VifUnpacker.State state;
-            do
+            while (unpacker.Run() != VifUnpacker.State.End)
             {
-                state = unpacker.Run();
-
                 var vpu = new MemoryStream(unpacker.Memory, false)
                     .Using(stream => VpuPacket.Read(stream));
 
@@ -152,7 +149,7 @@ namespace OpenKh.Engine.Parsers
                             break;
                     }
                 }
-            } while (state == VifUnpacker.State.Microprogram);
+            }
 
             return new MeshDescriptor
             {

--- a/OpenKh.Engine/Parsers/MdlxParser.cs
+++ b/OpenKh.Engine/Parsers/MdlxParser.cs
@@ -133,7 +133,13 @@ namespace OpenKh.Engine.Parsers
                     indexBuffer[(recentIndex++) & 3] = baseVertexIndex + i;
                     switch (vertexIndex.Function)
                     {
-                        case VpuPacket.VertexFunction.None:
+                        case VpuPacket.VertexFunction.DrawTriangleDoubleSided:
+                            indices.Add(indexBuffer[(recentIndex - 1) & 3]);
+                            indices.Add(indexBuffer[(recentIndex - 3) & 3]);
+                            indices.Add(indexBuffer[(recentIndex - 2) & 3]);
+                            indices.Add(indexBuffer[(recentIndex - 1) & 3]);
+                            indices.Add(indexBuffer[(recentIndex - 2) & 3]);
+                            indices.Add(indexBuffer[(recentIndex - 3) & 3]);
                             break;
                         case VpuPacket.VertexFunction.Stock:
                             break;

--- a/OpenKh.Engine/Parsers/MdlxParser.cs
+++ b/OpenKh.Engine/Parsers/MdlxParser.cs
@@ -44,7 +44,8 @@ namespace OpenKh.Engine.Parsers
                     {
                         Indices = x.Indices,
                         SegmentIndex = x.SegmentIndex,
-                        TextureIndex = x.TextureIndex
+                        TextureIndex = x.TextureIndex,
+                        IsOpaque = x.IsOpaque
                     }).ToArray()
                 };
             }
@@ -64,10 +65,11 @@ namespace OpenKh.Engine.Parsers
                     MdlxMatrixUtil.BuildTPoseMatrices(mdlx.SubModels.First(), Matrix.Identity)
                 );
 
-            var ci = builtModel.textureIndexBasedModelDict.Values.Select((model, i) => new Kddf2.Kkdf2MdlxParser.CI
+            var ci = builtModel.textureIndexBasedModelDict.Select((kv, i) => new Kddf2.Kkdf2MdlxParser.CI
             {
-                Indices = model.Vertices.Select((_, index) => index).ToArray(),
-                TextureIndex = i,
+                Indices = kv.Value.Vertices.Select((_, index) => index).ToArray(),
+                TextureIndex = kv.Key.Item1,
+                IsOpaque = kv.Key.Item2,
                 SegmentIndex = i
             });
 

--- a/OpenKh.Game/Content/KingdomShader.fx
+++ b/OpenKh.Game/Content/KingdomShader.fx
@@ -15,6 +15,7 @@ float2 TextureRegionV;
 int TextureWrapModeU;
 int TextureWrapModeV;
 Texture2D Texture0;
+bool UseAlphaMask;
 
 sampler2D TextureSampler = sampler_state
 {
@@ -76,8 +77,11 @@ float4 MainPS(VertexShaderOutput input) : COLOR
 		ApplyTextureWrap(input.TextureUv.x, TextureWrapModeU, TextureRegionU.x, TextureRegionU.y),
 		ApplyTextureWrap(input.TextureUv.y, TextureWrapModeV, TextureRegionV.x, TextureRegionV.y)
 		);
-
-	return tex2D(TextureSampler, uv) * input.Color;
+	float4 color = tex2D(TextureSampler, uv) * input.Color;
+	if (UseAlphaMask && color.a <= 0.125) {
+		clip(-1);
+	}
+	return color;
 }
 
 technique BasicColorDrawing

--- a/OpenKh.Ps2/VpuPacket.cs
+++ b/OpenKh.Ps2/VpuPacket.cs
@@ -9,7 +9,7 @@ namespace OpenKh.Ps2
     {
         public enum VertexFunction
         {
-            None = 0x00,
+            DrawTriangleDoubleSided = 0x00,
             Stock = 0x10,
             DrawTriangle = 0x20,
             DrawTriangleInverse = 0x30


### PR DESCRIPTION
Summary of changes with before/after comparison:

* Fix double/missing map geometry and some stray triangles.
* Support alpha masking for opaque meshes, and disable depth write in the blend passs for map meshes. This should resolve bad transparency and z-fighting in some areas.

![render-fixes-0](https://user-images.githubusercontent.com/49109252/91950331-36bfda00-ecb5-11ea-9587-01159f2715c4.png)

* Fix corrupted textures by skipping data deswizzling if the upload pixel format is not PSMCT32.

![render-fixes-1](https://user-images.githubusercontent.com/49109252/91950982-653db500-ecb5-11ea-98f4-34f78847b27b.png)

* Support alpha blending for entities for specific mesh segments where blending should be applied.

![render-fixes-2](https://user-images.githubusercontent.com/49109252/91952262-b9489980-ecb5-11ea-8e74-368fd6933701.png)