### PR TITLE
Specify line ending and formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,56 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+tab_size = 4
+
+[*.md]
+end_of_line = crlf
+
+[*.sln]
+end_of_line = crlf
+
+[*.csproj]
+end_of_line = crlf
+
+[*.cs]
+end_of_line = crlf
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_between_query_expression_clauses = true
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+csharp_indent_case_contents_when_block = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+csharp_using_directive_placement = outside_namespace

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*        text eol=lf
+*.cs     text eol=crlf diff=csharp
+*.md     text eol=crlf
+*.sln    text eol=crlf merge=union
+*.csproj text eol=crlf merge=union

--- a/OpenKh.sln
+++ b/OpenKh.sln
@@ -5,10 +5,6 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Kh2", "OpenKh.Kh2\OpenKh.Kh2.csproj", "{D5B36CD1-5B5D-4CE9-A673-209AD386D68A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DC4CA2F6-9A43-4112-92A8-8ACFF5E6C5A2}"
-	ProjectSection(SolutionItems) = preProject
-		LICENSE = LICENSE
-		README.md = README.md
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Tools.BarEditor", "OpenKh.Tools.BarEditor\OpenKh.Tools.BarEditor.csproj", "{5A6A483A-527E-4B96-9174-F0E648BCA950}"
 EndProject
@@ -108,9 +104,42 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Tests.Commands", "Op
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Tests.Engine", "OpenKh.Tests.Engine\OpenKh.Tests.Engine.csproj", "{198657C3-DC06-4AA6-A594-6D4D82218CA8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenKh.Ps2", "OpenKh.Ps2\OpenKh.Ps2.csproj", "{8D0CBCCA-3F3E-4775-B001-2DDA4D962A8A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Ps2", "OpenKh.Ps2\OpenKh.Ps2.csproj", "{8D0CBCCA-3F3E-4775-B001-2DDA4D962A8A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenKh.Tools.Kh2MapStudio", "OpenKh.Tools.Kh2MapStudio\OpenKh.Tools.Kh2MapStudio.csproj", "{77ADD488-0297-4EB7-9884-2068F84A9C67}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Tools.Kh2MapStudio", "OpenKh.Tools.Kh2MapStudio\OpenKh.Tools.Kh2MapStudio.csproj", "{77ADD488-0297-4EB7-9884-2068F84A9C67}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scripts", "Scripts", "{78098226-72BC-4492-9BA6-0283B4B9D2AB}"
+	ProjectSection(SolutionItems) = preProject
+		build.ps1 = build.ps1
+		build.sh = build.sh
+		openkh_alias = openkh_alias
+		pre-build.ps1 = pre-build.ps1
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{0C9861ED-5DCA-4DED-98B8-109031DE471B}"
+	ProjectSection(SolutionItems) = preProject
+		CNAME = CNAME
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{E74CBCC4-B979-44FD-AFFA-A89693483BF2}"
+	ProjectSection(SolutionItems) = preProject
+		CODE_GUIDELINE.md = CODE_GUIDELINE.md
+		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
+		CONTRIBUTING.md = CONTRIBUTING.md
+		LICENSE = LICENSE
+		NOTICE = NOTICE
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Settings", "Settings", "{6B47410F-F5F8-4F79-B4D7-936C698E6805}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Pipelines", "Pipelines", "{064EB64F-FAFF-4FE8-8711-EC2CF260669C}"
+	ProjectSection(SolutionItems) = preProject
+		azure-pipelines.yml = azure-pipelines.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -910,6 +939,11 @@ Global
 		{198657C3-DC06-4AA6-A594-6D4D82218CA8} = {939E8104-3A37-41FC-A411-CAEE67A803B6}
 		{8D0CBCCA-3F3E-4775-B001-2DDA4D962A8A} = {0FB7CD6A-EE31-467D-A590-267DCD028618}
 		{77ADD488-0297-4EB7-9884-2068F84A9C67} = {402B2669-D594-4DFA-965B-02A92626ADC6}
+		{78098226-72BC-4492-9BA6-0283B4B9D2AB} = {DC4CA2F6-9A43-4112-92A8-8ACFF5E6C5A2}
+		{0C9861ED-5DCA-4DED-98B8-109031DE471B} = {DC4CA2F6-9A43-4112-92A8-8ACFF5E6C5A2}
+		{E74CBCC4-B979-44FD-AFFA-A89693483BF2} = {DC4CA2F6-9A43-4112-92A8-8ACFF5E6C5A2}
+		{6B47410F-F5F8-4F79-B4D7-936C698E6805} = {DC4CA2F6-9A43-4112-92A8-8ACFF5E6C5A2}
+		{064EB64F-FAFF-4FE8-8711-EC2CF260669C} = {DC4CA2F6-9A43-4112-92A8-8ACFF5E6C5A2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1DF3960B-4FE5-4E56-92D4-2FC0A912E823}


### PR DESCRIPTION
I need to gain again some momentum in this project. This is a very small PR that suggests contributors to strict code formatting rules. I also became aware that shell scripts on Linux do not work with `crlf` line ending. Since there are minor inconsistencies between the text encoding and line ending, the rules will force the editor to always use UTF-8 without BOM and `lf` in all occasions with few exceptions.