### PR TITLE
Add command line support to OpenKh.Tools.Kh2MapStudio

### DIFF
--- a/OpenKh.Tools.Kh2MapStudio/App.cs
+++ b/OpenKh.Tools.Kh2MapStudio/App.cs
@@ -96,7 +96,7 @@ namespace OpenKh.Tools.Kh2MapStudio
         private bool IsMapOpen => !string.IsNullOrEmpty(_mapName);
         private bool IsOpen => IsGameOpen && IsMapOpen;
 
-        public App(MonoGameImGuiBootstrap bootstrap)
+        public App(MonoGameImGuiBootstrap bootstrap, string gamePath = null)
         {
             _bootstrap = bootstrap;
             _bootstrap.Title = Title;
@@ -104,7 +104,7 @@ namespace OpenKh.Tools.Kh2MapStudio
             AddKeyMapping(Keys.O, MenuFileOpen);
             AddKeyMapping(Keys.S, MenuFileSave);
             AddKeyMapping(Keys.Q, MenuFileUnload);
-            OpenFolder(@"D:\Hacking\KH2\export_fm");
+            OpenFolder(gamePath ?? @"D:\Hacking\KH2\export_fm");
 
             ImGui.PushStyleColor(ImGuiCol.MenuBarBg, BgUiColor);
         }

--- a/OpenKh.Tools.Kh2MapStudio/OpenKh.Tools.Kh2MapStudio.csproj
+++ b/OpenKh.Tools.Kh2MapStudio/OpenKh.Tools.Kh2MapStudio.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
@@ -26,6 +26,7 @@
 		<PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
 		<PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.0.7" />
 		<PackageReference Include="AssimpNet" Version="5.0.0-beta1" />
+		<PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/OpenKh.Tools.Kh2MapStudio/Program.cs
+++ b/OpenKh.Tools.Kh2MapStudio/Program.cs
@@ -1,34 +1,53 @@
-﻿using OpenKh.Tools.Common.CustomImGui;
+using McMaster.Extensions.CommandLineUtils;
+using OpenKh.Tools.Common.CustomImGui;
 using System;
+using System.Reflection;
 
 namespace OpenKh.Tools.Kh2MapStudio
 {
+    [Command("OpenKh.Tools.Kh2MapStudio")]
+    [VersionOptionFromMember("--version", MemberName = nameof(GetVersion))]
     class Program : IDisposable
     {
         [STAThread]
-        static void Main(string[] args)
+        static int Main(string[] args)
         {
-            using var program = new Program(args);
-            program.Run();
+            return CommandLineApplication.Execute<Program>(args);
         }
+
+        protected int OnExecute(CommandLineApplication app)
+        {
+            Run();
+            return 0;
+        }
+
+        #region CommandLine
+        private static string GetVersion()
+            => typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+
+        [Argument(0, "KH2 GamePath")]
+        public string GamePath { get; }
+        #endregion
 
         const int InitialWindowWidth = 1000;
         const int InitialWindowHeight = 800;
         private readonly MonoGameImGuiBootstrap _bootstrap;
         private App _app;
 
-        public Program(string[] args)
+        public Program()
         {
             _bootstrap = new MonoGameImGuiBootstrap(
                 InitialWindowWidth,
                 InitialWindowHeight,
                 Initialize);
             _bootstrap.MainLoop = MainLoop;
+
+
         }
 
         private void Initialize(MonoGameImGuiBootstrap bootstrap)
         {
-            _app = new App(bootstrap);
+            _app = new App(bootstrap, GamePath);
         }
 
         public void Run()


### PR DESCRIPTION
You can specify `<KH2 GamePath>` at command line.

```bat
H:\Proj\OpenKh>H:\Proj\OpenKh\OpenKh.Tools.Kh2MapStudio\bin\Debug\netcoreapp3.1\OpenKh.Tools.Kh2MapStudio.exe --help > help.txt

H:\Proj\OpenKh>type help.txt
1.0.0

Usage: OpenKh.Tools.Kh2MapStudio [options] <KH2 GamePath>

Arguments:
  KH2 GamePath

Options:
  --version     Show version information
  -?|-h|--help  Show help information
```

Usage

```bat
H:\Proj\OpenKh>H:\Proj\OpenKh\OpenKh.Tools.Kh2MapStudio\bin\Debug\netcoreapp3.1\OpenKh.Tools.Kh2MapStudio.exe H:\KH2fm.OpenKH
```

After launch:

![2020-11-12_23h29_44](https://user-images.githubusercontent.com/5955540/98952572-f5626b00-253e-11eb-9e87-e75623cd899f.png)


Fix #269 