### PR TITLE
Add FBX model loader

### DIFF
--- a/OpenKh.Engine.MonoGame/Extensions.cs
+++ b/OpenKh.Engine.MonoGame/Extensions.cs
@@ -18,12 +18,12 @@ namespace OpenKh.Engine.MonoGame
             return texture;
         }
 
-        public static void SetRenderTexture(this KingdomShader shader, EffectPass pass, KingdomTexture texture)
+        public static void SetRenderTexture(this KingdomShader shader, EffectPass pass, IKingdomTexture texture)
         {
             if (shader.Texture0 != texture.Texture2D)
             {
                 shader.Texture0 = texture.Texture2D;
-                switch (texture.ModelTexture.TextureAddressMode.AddressU)
+                switch (texture.AddressU)
                 {
                     case ModelTexture.TextureWrapMode.Clamp:
                         shader.TextureRegionU = KingdomShader.DefaultTextureRegion;
@@ -42,7 +42,7 @@ namespace OpenKh.Engine.MonoGame
                         shader.TextureWrapModeU = TextureWrapMode.Repeat;
                         break;
                 }
-                switch (texture.ModelTexture.TextureAddressMode.AddressV)
+                switch (texture.AddressV)
                 {
                     case ModelTexture.TextureWrapMode.Clamp:
                         shader.TextureRegionV = KingdomShader.DefaultTextureRegion;

--- a/OpenKh.Engine.MonoGame/KingdomTexture.cs
+++ b/OpenKh.Engine.MonoGame/KingdomTexture.cs
@@ -1,11 +1,46 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using OpenKh.Common;
 using OpenKh.Kh2;
 using System;
+using System.IO;
 
 namespace OpenKh.Engine.MonoGame
 {
-    public class KingdomTexture : IDisposable
+    public interface IKingdomTexture : IDisposable
+    {
+        Texture2D Texture2D { get; }
+        ModelTexture.TextureWrapMode AddressU { get; }
+        ModelTexture.TextureWrapMode AddressV { get; }
+        Vector2 RegionU { get; }
+        Vector2 RegionV { get; }
+    }
+
+    public class PngKingdomTexture : IKingdomTexture
+    {
+        private static readonly Vector2 DefaultRegion = new Vector2(0, 1);
+
+        public PngKingdomTexture(string filePath, GraphicsDevice graphics)
+        {
+            Texture2D = File.OpenRead(filePath)
+                .Using(x => Texture2D.FromStream(graphics, x));
+        }
+
+        public Texture2D Texture2D { get; }
+
+        public ModelTexture.TextureWrapMode AddressU => ModelTexture.TextureWrapMode.Repeat;
+        public ModelTexture.TextureWrapMode AddressV => ModelTexture.TextureWrapMode.Repeat;
+
+        public Vector2 RegionU => DefaultRegion;
+        public Vector2 RegionV => DefaultRegion;
+
+        public void Dispose()
+        {
+            Texture2D?.Dispose();
+        }
+    }
+
+    public class KingdomTexture : IKingdomTexture
     {
         public KingdomTexture(ModelTexture.Texture texture, GraphicsDevice graphics)
         {
@@ -23,6 +58,12 @@ namespace OpenKh.Engine.MonoGame
         public Vector2 RegionV => new Vector2(
             (float)Math.Min(ModelTexture.TextureAddressMode.Top, ModelTexture.TextureAddressMode.Bottom) / Texture2D.Height,
             (float)Math.Max(ModelTexture.TextureAddressMode.Top, ModelTexture.TextureAddressMode.Bottom) / Texture2D.Height);
+
+        public ModelTexture.TextureWrapMode AddressU =>
+            ModelTexture.TextureAddressMode.AddressU;
+
+        public ModelTexture.TextureWrapMode AddressV =>
+            ModelTexture.TextureAddressMode.AddressV;
 
         public void Dispose()
         {

--- a/OpenKh.Engine.MonoGame/MeshGroup.cs
+++ b/OpenKh.Engine.MonoGame/MeshGroup.cs
@@ -1,11 +1,10 @@
-﻿using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 
 namespace OpenKh.Engine.MonoGame
 {
     public class MeshGroup
     {
-        public KingdomTexture[] Textures { get; set; }
+        public IKingdomTexture[] Textures { get; set; }
         public List<MeshDesc> MeshDescriptors { get; set; }
     }
 }

--- a/OpenKh.Engine/OpenKh.Engine.csproj
+++ b/OpenKh.Engine/OpenKh.Engine.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="AssimpNet" Version="5.0.0-beta1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenKh.Game/Entities/ObjectEntity.cs
+++ b/OpenKh.Game/Entities/ObjectEntity.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using OpenKh.Engine.MonoGame;
 using OpenKh.Game.Debugging;
@@ -6,6 +6,8 @@ using OpenKh.Game.Infrastructure;
 using OpenKh.Kh2;
 using OpenKh.Kh2.Ard;
 using OpenKh.Kh2.Extensions;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace OpenKh.Game.Entities
@@ -50,6 +52,45 @@ namespace OpenKh.Game.Entities
             var model = entries.ForEntry(x => x.Type == Bar.EntryType.Model, Mdlx.Read);
             var texture = entries.ForEntry("tim_", Bar.EntryType.ModelTexture, ModelTexture.Read);
             Mesh = MeshLoader.FromKH2(graphics, model, texture);
+        }
+
+        public static MeshGroup FromFbx(GraphicsDevice graphics, string filePath)
+        {
+            const float Scale = 96.0f;
+            var assimp = new Assimp.AssimpContext();
+            var scene = assimp.ImportFile(filePath, Assimp.PostProcessSteps.PreTransformVertices);
+            var baseFilePath = Path.GetDirectoryName(filePath);
+
+            return new MeshGroup()
+            {
+                MeshDescriptors = scene.Meshes
+                    .Select(x =>
+                    {
+                        var vertices = new VertexPositionColorTexture[x.Vertices.Count];
+                        for (var i = 0; i < vertices.Length; i++)
+                        {
+                            vertices[i].Position.X = x.Vertices[i].X * Scale;
+                            vertices[i].Position.Y = x.Vertices[i].Y * Scale;
+                            vertices[i].Position.Z = x.Vertices[i].Z * Scale;
+                            vertices[i].TextureCoordinate.X = x.TextureCoordinateChannels[0][i].X;
+                            vertices[i].TextureCoordinate.Y = 1.0f - x.TextureCoordinateChannels[0][i].Y;
+                            vertices[i].Color = Color.White;
+                        }
+
+                        return new MeshDesc
+                        {
+                            Vertices = vertices,
+                            Indices = x.Faces.SelectMany(f => f.Indices).ToArray(),
+                            IsOpaque = true,
+                            TextureIndex = x.MaterialIndex
+                        };
+                    }).ToList(),
+                Textures = scene.Materials.Select(x =>
+                {
+                    var path = Path.Join(baseFilePath, $"{x.Name}.png");
+                    return new PngKingdomTexture(path, graphics);
+                }).ToArray(),
+            };
         }
 
         public static ObjectEntity FromSpawnPoint(Kernel kernel, SpawnPoint.Entity spawnPoint) =>


### PR DESCRIPTION
Allow to load FBX models with their PNG textures into OpenKH game engine. Thanks to this it is now possible to show models from Kingdom Hearts Melody of Memory and not only as FBX is a very wide and supported format.

![image](https://user-images.githubusercontent.com/6128729/99121522-6fa0f700-25f4-11eb-8629-c82c390975c0.png)

This PR will not change the behaviour of the current game engine. If you want to achieve the result shown in the screenshot above, paste this portion of code in `LoadMesh` function from `ObjectEntry.cs`. Of course replace the path with the one from your computer.
```csharp
if (objEntry.ModelName == "PLAYER")
{
    Mesh = FromFbx(graphics, @"D:\KHMOM\CHARACTER0000033\CHARACTER0000033_md.fbx");
    return;
}
```