### PR TITLE
MapStudio remembers last game folder open

### DIFF
--- a/OpenKh.Tools.Kh2MapStudio/App.cs
+++ b/OpenKh.Tools.Kh2MapStudio/App.cs
@@ -104,7 +104,9 @@ namespace OpenKh.Tools.Kh2MapStudio
             AddKeyMapping(Keys.O, MenuFileOpen);
             AddKeyMapping(Keys.S, MenuFileSave);
             AddKeyMapping(Keys.Q, MenuFileUnload);
-            OpenFolder(gamePath ?? @"D:\Hacking\KH2\export_fm");
+
+            if (!string.IsNullOrEmpty(gamePath))
+                OpenFolder(gamePath);
 
             ImGui.PushStyleColor(ImGuiCol.MenuBarBg, BgUiColor);
         }

--- a/OpenKh.Tools.Kh2MapStudio/App.cs
+++ b/OpenKh.Tools.Kh2MapStudio/App.cs
@@ -75,6 +75,9 @@ namespace OpenKh.Tools.Kh2MapStudio
                     Path.Combine(_gamePath, "00objentry.bin"));
                 _mapRenderer.ObjEntryController = _objEntryController;
 
+                Settings.Default.GamePath = value;
+                Settings.Default.Save();
+
             }
         }
 
@@ -104,6 +107,9 @@ namespace OpenKh.Tools.Kh2MapStudio
             AddKeyMapping(Keys.O, MenuFileOpen);
             AddKeyMapping(Keys.S, MenuFileSave);
             AddKeyMapping(Keys.Q, MenuFileUnload);
+
+            if (string.IsNullOrEmpty(gamePath))
+                gamePath = Settings.Default.GamePath;
 
             if (!string.IsNullOrEmpty(gamePath))
                 OpenFolder(gamePath);

--- a/OpenKh.Tools.Kh2MapStudio/Settings.Designer.cs
+++ b/OpenKh.Tools.Kh2MapStudio/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace OpenKh.Tools.Kh2MapStudio {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -140,6 +140,18 @@ namespace OpenKh.Tools.Kh2MapStudio {
             }
             set {
                 this["ViewSpawnScriptEvent"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string GamePath {
+            get {
+                return ((string)(this["GamePath"]));
+            }
+            set {
+                this["GamePath"] = value;
             }
         }
     }

--- a/OpenKh.Tools.Kh2MapStudio/Settings.settings
+++ b/OpenKh.Tools.Kh2MapStudio/Settings.settings
@@ -32,5 +32,8 @@
     <Setting Name="ViewSpawnScriptEvent" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="GamePath" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Following #269 and #277 , I am removing a hardcoded path that has been pushed by mistake. Also when you open the application, the tool will try to open the last open game folder.