### PR TITLE
Boot parameters for OpenKH game engine

### DIFF
--- a/OpenKh.Common/DictionaryExtensions.cs
+++ b/OpenKh.Common/DictionaryExtensions.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace OpenKh.Common
+{
+    public static class DictionaryExtensions
+    {
+        public static string GetString(
+            this IDictionary<string, string> dic, string key, string defaultValue) =>
+            dic.TryGetValue(key, out var value) ? value : defaultValue;
+
+        public static int GetInt(
+            this IDictionary<string, string> dic, string key, int defaultValue) =>
+            int.TryParse(dic.GetSetting(key, string.Empty), out var value) ? value : defaultValue;
+
+        public static bool GetBool(
+            this IDictionary<string, string> dic, string key, bool defaultValue) =>
+            bool.TryParse(dic.GetSetting(key, string.Empty), out var value) ? value : defaultValue;
+
+        public static double GetDouble(
+            this IDictionary<string, string> dic, string key, double defaultValue) =>
+            double.TryParse(dic.GetSetting(key, string.Empty), out var value) ? value : defaultValue;
+
+        public static T GetSetting<T>(
+            this IDictionary<string, string> dic, string key, T defaultValue)
+        {
+            var type = typeof(T);
+            if (type == typeof(string))
+                return (T)(object)dic.GetString(key, (string)(object)defaultValue);
+            if (type == typeof(int))
+                return int.TryParse(dic.GetSetting(key, string.Empty), out var value) ?
+                    (T)(object)value : defaultValue;
+            if (type == typeof(bool))
+                return bool.TryParse(dic.GetSetting(key, string.Empty), out var value) ?
+                    (T)(object)value : defaultValue;
+            if (type == typeof(double))
+                return double.TryParse(dic.GetSetting(key, string.Empty), out var value) ?
+                    (T)(object)value : defaultValue;
+
+            return defaultValue;
+        }
+    }
+}

--- a/OpenKh.Game/Infrastructure/StateInitDesc.cs
+++ b/OpenKh.Game/Infrastructure/StateInitDesc.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using OpenKh.Game.States;
+using System.Collections.Generic;
 
 namespace OpenKh.Game.Infrastructure
 {
@@ -13,5 +14,6 @@ namespace OpenKh.Game.Infrastructure
         public ContentManager ContentManager { get; set; }
         public GraphicsDeviceManager GraphicsDevice { get; set; }
         public IStateChange StateChange { get; set; }
+        public Dictionary<string, string> StateSettings { get; set; }
     }
 }

--- a/OpenKh.Game/OpenKh.Game.csproj
+++ b/OpenKh.Game/OpenKh.Game.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -16,6 +16,7 @@
     <PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
     <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.0.7" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
+	<PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -11,6 +11,11 @@ using System.Linq;
 
 namespace OpenKh.Game
 {
+    public class OpenKhGameStartup
+    {
+        public string ContentPath { get; set; }
+    }
+
     public class OpenKhGame : Microsoft.Xna.Framework.Game, IStateChange
     {
         private GraphicsDeviceManager graphics;
@@ -56,9 +61,9 @@ namespace OpenKh.Game
             }
         }
 
-        public OpenKhGame(string[] args)
+        public OpenKhGame(OpenKhGameStartup startup)
         {
-            var contentPath = args.FirstOrDefault() ?? Config.DataPath;
+            var contentPath = startup.ContentPath ?? Config.DataPath;
 
             _dataContent = CreateDataContent(contentPath, Config.IdxFilePath, Config.ImgFilePath);
             _dataContent = new MultipleDataContent(new ModDataContent(), _dataContent);

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -6,25 +6,33 @@ using OpenKh.Game.Infrastructure;
 using OpenKh.Game.States;
 using OpenKh.Game.States.Title;
 using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace OpenKh.Game
 {
     public class OpenKhGameStartup
     {
-        public string ContentPath { get; set; }
+        public string ContentPath { get; internal set; }
+        public int InitialState { get; internal set; }
+        public int InitialMap { get; internal set; }
+        public int InitialPlace { get; internal set; }
+        public int InitialSpawnScriptMap { get; internal set; }
+        public int InitialSpawnScriptBtl { get; internal set; }
+        public int InitialSpawnScriptEvt { get; internal set; }
     }
 
     public class OpenKhGame : Microsoft.Xna.Framework.Game, IStateChange
     {
         private GraphicsDeviceManager graphics;
 
+        private readonly Dictionary<string, string> GlobalSettings;
         private readonly IDataContent _dataContent;
         private readonly Kernel _kernel;
         private readonly ArchiveManager archiveManager;
         private readonly InputManager inputManager;
         private readonly DebugOverlay _debugOverlay;
+        private readonly OpenKhGameStartup _startup;
         private IState state;
         private bool _isResolutionChanged;
 
@@ -63,6 +71,15 @@ namespace OpenKh.Game
 
         public OpenKhGame(OpenKhGameStartup startup)
         {
+            _startup = startup;
+            GlobalSettings = new Dictionary<string, string>();
+            TryAddSetting("WorldId", startup.InitialMap);
+            TryAddSetting("PlaceId", startup.InitialPlace);
+            //TryAddSetting("SpawnId", );
+            TryAddSetting("SpawnScriptMap", startup.InitialSpawnScriptMap);
+            TryAddSetting("SpawnScriptBtl", startup.InitialSpawnScriptBtl);
+            TryAddSetting("SpawnScriptEvt", startup.InitialSpawnScriptEvt);
+
             var contentPath = startup.ContentPath ?? Config.DataPath;
 
             _dataContent = CreateDataContent(contentPath, Config.IdxFilePath, Config.ImgFilePath);
@@ -119,7 +136,7 @@ namespace OpenKh.Game
         protected override void Initialize()
         {
             _debugOverlay.Initialize(GetStateInitDesc());
-            State = 0;
+            State = _startup.InitialState;
 
             base.Initialize();
         }
@@ -163,6 +180,18 @@ namespace OpenKh.Game
             base.Draw(gameTime);
         }
 
+        private void TryAddSetting(string key, string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+                GlobalSettings.Add(key, value);
+        }
+
+        private void TryAddSetting(string key, int value)
+        {
+            if (value >= 0)
+                GlobalSettings.Add(key, value.ToString());
+        }
+
         private StateInitDesc GetStateInitDesc()
         {
             return new StateInitDesc
@@ -174,6 +203,7 @@ namespace OpenKh.Game
                 ContentManager = Content,
                 GraphicsDevice = graphics,
                 StateChange = this,
+                StateSettings = GlobalSettings,
             };
         }
 

--- a/OpenKh.Game/Program.cs
+++ b/OpenKh.Game/Program.cs
@@ -2,6 +2,7 @@ using McMaster.Extensions.CommandLineUtils;
 using OpenKh.Game.Debugging;
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Reflection;
 
 namespace OpenKh.Game
@@ -54,11 +55,43 @@ namespace OpenKh.Game
         [Argument(0, "Content path", "Location of game's data")]
         public string ContentPath { get; }
 
+        [Option(ShortName = "state", Description = "Boot the game into a specific state (0 = Title, 1 = Map, 2 = Menu)")]
+        public int InitialState { get; set; }
+
+        [Option(ShortName = "world", Description = "Boot the game into a specific world ID (eg. 'dc')")]
+        public string InitialWorld { get; set; }
+
+        [Option(ShortName = "place", Description = "Boot the game into a specific place ID (eg. for dc06 specify '6')")]
+        public int InitialPlace { get; set; }
+
+        [Option(ShortName = "spawn-map", Description = "Force the boot map to use a specific spawn script program ID for MAP")]
+        public int InitialSpawnScriptMap { get; set; }
+
+        [Option(ShortName = "spawn-btl", Description = "Force the boot map to use a specific spawn script program ID for BTL")]
+        public int InitialSpawnScriptBtl { get; set; }
+
+        [Option(ShortName = "spawn-evt", Description = "Force the boot map to use a specific spawn script program ID for EVT")]
+        public int InitialSpawnScriptEvt { get; set; }
+
         private void OnExecute()
         {
             using var game = new OpenKhGame(new OpenKhGameStartup
             {
-                ContentPath = ContentPath
+                ContentPath = ContentPath,
+                InitialState = InitialState,
+                InitialMap = Kh2.Constants.WorldIds
+                    .Select((world, index) => (world, index))
+                    .Concat(new (string world, int index)[]
+                    {
+                        (InitialWorld, -1)
+                    })
+                    .Where(x => x.world == InitialWorld)
+                    .Select(x => x.index)
+                    .FirstOrDefault(),
+                InitialPlace = InitialPlace,
+                InitialSpawnScriptMap = InitialSpawnScriptMap,
+                InitialSpawnScriptBtl = InitialSpawnScriptBtl,
+                InitialSpawnScriptEvt = InitialSpawnScriptEvt,
             });
 
             game.Run();

--- a/OpenKh.Game/Program.cs
+++ b/OpenKh.Game/Program.cs
@@ -69,22 +69,22 @@ namespace OpenKh.Game
         [Option(CommandOptionType.NoValue, ShortName = "v", LongName = "console", Description = "Show the console output (Windows only)")]
         public bool ShowConsole { get; set; }
 
-        [Option(ShortName = "state", Description = "Boot the game into a specific state (0 = Title, 1 = Map, 2 = Menu)")]
+        [Option("--state <ID>", "Boot the game into a specific state (0 = Title, 1 = Map, 2 = Menu)", CommandOptionType.SingleValue)]
         public int InitialState { get; set; }
 
-        [Option(ShortName = "world", Description = "Boot the game into a specific world ID (eg. 'dc')")]
+        [Option("--world <ID>", "Boot the game into a specific world ID (eg. 'dc')", CommandOptionType.SingleValue)]
         public string InitialWorld { get; set; }
 
-        [Option(ShortName = "place", Description = "Boot the game into a specific place ID (eg. for dc06 specify '6')")]
+        [Option("--place <INDEX>", "Boot the game into a specific place ID (eg. for dc06 specify '6')", CommandOptionType.SingleValue)]
         public int InitialPlace { get; set; }
 
-        [Option(ShortName = "spawn-map", Description = "Force the boot map to use a specific spawn script program ID for MAP")]
+        [Option("--spawn-map <PROGRAM_ID>", "Force the boot map to use a specific spawn script program ID for MAP", CommandOptionType.SingleValue)]
         public int InitialSpawnScriptMap { get; set; }
 
-        [Option(ShortName = "spawn-btl", Description = "Force the boot map to use a specific spawn script program ID for BTL")]
+        [Option("--spawn-btl <PROGRAM_ID>", "Force the boot map to use a specific spawn script program ID for BTL", CommandOptionType.SingleValue)]
         public int InitialSpawnScriptBtl { get; set; }
 
-        [Option(ShortName = "spawn-evt", Description = "Force the boot map to use a specific spawn script program ID for EVT")]
+        [Option("--spawn-evt <PROGRAM_ID>", "Force the boot map to use a specific spawn script program ID for EVT", CommandOptionType.SingleValue)]
         public int InitialSpawnScriptEvt { get; set; }
 
         private void OnExecute()

--- a/OpenKh.Game/States/MapState.cs
+++ b/OpenKh.Game/States/MapState.cs
@@ -40,9 +40,12 @@ namespace OpenKh.Game.States
         private KingdomShader _shader;
         private Camera _camera;
 
-        private int _worldId = 2;
-        private int _placeId = 4;
-        private int _spawnId = 99;
+        private int _worldId;
+        private int _placeId;
+        private int _spawnId;
+        private int _spawnScriptMap;
+        private int _spawnScriptBtl;
+        private int _spawnScriptEvt;
 
         private int _objEntryId = 0x236; // PLAYER
         private bool _enableCameraMovement = true;
@@ -66,6 +69,12 @@ namespace OpenKh.Game.States
                 CameraRotationYawPitchRoll = new Vector3(90, 0, 10),
             };
             _menuState = new MenuState(this);
+            _worldId = initDesc.StateSettings.GetInt("WorldId", 2);
+            _placeId = initDesc.StateSettings.GetInt("PlaceId", 4);
+            _spawnId = initDesc.StateSettings.GetInt("SpawnId", 99);
+            _spawnScriptMap = initDesc.StateSettings.GetInt("SpawnScriptMap", 0x06);
+            _spawnScriptBtl = initDesc.StateSettings.GetInt("SpawnScriptBtl", 0x01);
+            _spawnScriptEvt = initDesc.StateSettings.GetInt("SpawnScriptEvt", 0x16);
 
             BasicallyForceToReloadEverything();
             _menuState.Initialize(initDesc);
@@ -233,9 +242,9 @@ namespace OpenKh.Game.States
                 fileName = $"ard/{Constants.WorldIds[worldIndex]}{placeIndex:D02}.ard";
 
             var entries = _dataContent.FileOpen(fileName).Using(Bar.Read);
-            RunSpawnScript(entries, "map", 0x06);
-            RunSpawnScript(entries, "btl", 0x01);
-            RunSpawnScript(entries, "evt", 0x16);
+            RunSpawnScript(entries, "map", _spawnScriptMap);
+            RunSpawnScript(entries, "btl", _spawnScriptBtl);
+            RunSpawnScript(entries, "evt", _spawnScriptEvt);
         }
 
         private void RunSpawnScript(IEnumerable<Bar.Entry> barEntries, string spawnScriptName, int programId)


### PR DESCRIPTION
A feature I use A LOT while I work with our game engine is that I want to boot straight to a specific map with specific settings. Every time I end up modifying manually the code and try to remember to not commit it. This is not an ideal scenario.

The pull request allows to do so by specifying the required boot settings from a command line. Since you usually set arguments in the "debug" tab of Visual Studio (or whatever is your favourite IDE), this will allow very fast testing. For example, when I want to spawn into "The Dark Margin" map I can just use the arguments `.\KH2\export_fm -v -state 1 -world es -place 0 -spawn-map 25`. 

You can also invoke `dotnet OpenKh.Game.dll --help` to know more about the possible settings:

![Untitled](https://user-images.githubusercontent.com/6128729/99130770-2dce7b80-2609-11eb-9574-b746aa77c29d.png)


