### PR TITLE
Upgrade to .NET Core 3.1 for every library

### DIFF
--- a/OpenKh.Bbs/OpenKh.Bbs.csproj
+++ b/OpenKh.Bbs/OpenKh.Bbs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.Common/OpenKh.Common.csproj
+++ b/OpenKh.Common/OpenKh.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.Engine/OpenKh.Engine.csproj
+++ b/OpenKh.Engine/OpenKh.Engine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.Imaging/OpenKh.Imaging.csproj
+++ b/OpenKh.Imaging/OpenKh.Imaging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.Kh2/OpenKh.Kh2.csproj
+++ b/OpenKh.Kh2/OpenKh.Kh2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.Ps2/OpenKh.Ps2.csproj
+++ b/OpenKh.Ps2/OpenKh.Ps2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The low level libraries were using .NET Standard 2.0 and the only reason for that was to have backward compatibility with .NET Framework 4.7.2. Now that we have all the tools in .NET Core 3.1 and .NET 5 recently became a thing, there is no need anymore to shy away from .NET Core 3.1 features for the low level libraries.