### PR TITLE
Fix bug where OpenKh.Game always need at least an argument

### DIFF
--- a/OpenKh.Game/Program.cs
+++ b/OpenKh.Game/Program.cs
@@ -62,8 +62,7 @@ namespace OpenKh.Game
         private static string GetVersion() => ProductVersion;
 
 
-        [Required]
-        [Argument(0, "Content path", "Location of game's data")]
+        [Option("--data <GAME_PATH>", "Location of game's data", CommandOptionType.SingleValue)]
         public string ContentPath { get; }
 
         [Option(CommandOptionType.NoValue, ShortName = "v", LongName = "console", Description = "Show the console output (Windows only)")]


### PR DESCRIPTION
An user mentioned a [unexpected behaviour](https://discord.com/channels/409140906625728532/567061704849096725/779595641135300608) in the latest builds of OpenKh.Game. I realised that the mistake was that the game was always asking for the game's path as a command line argument. This fixes the issue.

NOTE: From now on you will need to change your debugging configuration by specifying `--path YOUR_GAME_PATH` if you do not want to use the settings from `config.yml`.