### PR TITLE
Fix various issues linked to fontimage usage

### DIFF
--- a/OpenKh.Engine/Extensions/ImageReadExtensions.cs
+++ b/OpenKh.Engine/Extensions/ImageReadExtensions.cs
@@ -1,4 +1,4 @@
-﻿using OpenKh.Imaging;
+using OpenKh.Imaging;
 using System;
 
 namespace OpenKh.Engine.Extensions
@@ -46,8 +46,8 @@ namespace OpenKh.Engine.Extensions
                 for (var i = 0; i < size.Width / 2; i++)
                 {
                     var ch = data[srcIndex++];
-                    var palIndex1 = (ch & 15);
-                    var palIndex2 = (ch >> 4);
+                    var palIndex1 = (ch >> 4);
+                    var palIndex2 = (ch & 15);
                     dstData[dstIndex++] = clut[palIndex1 * 4 + channelOrder[0]];
                     dstData[dstIndex++] = clut[palIndex1 * 4 + channelOrder[1]];
                     dstData[dstIndex++] = clut[palIndex1 * 4 + channelOrder[2]];

--- a/OpenKh.Engine/Renders/IMessageRenderer.cs
+++ b/OpenKh.Engine/Renders/IMessageRenderer.cs
@@ -1,4 +1,4 @@
-﻿namespace OpenKh.Engine.Renders
+namespace OpenKh.Engine.Renders
 {
     public class DrawContext
     {
@@ -13,7 +13,10 @@
         public double Height;
         public double WindowWidth;
 
-        public float ScaleX => (float)(WidthMultiplier * Scale * 0.85);
+        public float ScaleX => (float)(WidthMultiplier * Scale * GlobalScale);
+
+        // A scale of 0.85 is the one that is apparently used in-game
+        public double GlobalScale { get; set; } = 0.85;
 
         public DrawContext()
         {

--- a/OpenKh.Imaging/ImageDataHelpers.cs
+++ b/OpenKh.Imaging/ImageDataHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 
 namespace OpenKh.Imaging
@@ -104,6 +104,12 @@ namespace OpenKh.Imaging
             }
 
             return dst;
+        }
+
+        public static void SwapEndianIndexed4(byte[] data)
+        {
+            for (var i = 0; i < data.Length; i++)
+                data[i] = (byte)(((data[i] & 0x0F) << 4) | (data[i] >> 4));
         }
     }
 }

--- a/OpenKh.Kh2/RawBitmap.cs
+++ b/OpenKh.Kh2/RawBitmap.cs
@@ -30,6 +30,7 @@ namespace OpenKh.Kh2
             var reader = new BinaryReader(stream);
             var bpp = is8bit ? 8 : 4;
             _data = reader.ReadBytes(width * height * bpp / 8);
+            ImageDataHelpers.SwapEndianIndexed4(_data);
 
             // If we did not reached the end of the stream, then it does mean that there is a palette
             if (stream.Position < stream.Length)

--- a/OpenKh.Tools.Common/Controls/KingdomTextArea.cs
+++ b/OpenKh.Tools.Common/Controls/KingdomTextArea.cs
@@ -1,4 +1,4 @@
-﻿using OpenKh.Kh2.Messages;
+using OpenKh.Kh2.Messages;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Windows;
@@ -68,7 +68,10 @@ namespace OpenKh.Tools.Common.Controls
 
             DrawBackground();
 
-            Draw(new DrawContext(), MessageCommands);
+            Draw(new DrawContext()
+            {
+                GlobalScale = 1.0
+            }, MessageCommands);
             Drawing.Flush();
         }
 

--- a/OpenKh.Tools.ImageViewer/Services/ImageFormatService.cs
+++ b/OpenKh.Tools.ImageViewer/Services/ImageFormatService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -30,6 +30,8 @@ namespace OpenKh.Tools.ImageViewer.Services
 
                 GetImageFormat("IMGZ", "imz", true, Imgz.IsValid, s => Imgz.Read(s), (stream, images) =>
                     Imgz.Write(stream, images.Select(x => x.AsImgd()))),
+
+                GetImageFormat("KH2 Font", "bar", true, IsKh2Font, ReadKh2Font, WriteKh2Font),
 
                 GetImageFormat("Font ARC", "arc", false, FontsArc.IsValid, s =>
                 {

--- a/OpenKh.Tools.ImageViewer/Services/ImageFormatSevice.Kh2Font.cs
+++ b/OpenKh.Tools.ImageViewer/Services/ImageFormatSevice.Kh2Font.cs
@@ -1,0 +1,44 @@
+using OpenKh.Common;
+using OpenKh.Imaging;
+using OpenKh.Kh2;
+using OpenKh.Kh2.Contextes;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace OpenKh.Tools.ImageViewer.Services
+{
+    public partial class ImageFormatService
+    {
+        private static bool IsKh2Font(Stream inputStream)
+        {
+            if (!Bar.IsValid(inputStream.SetPosition(0)))
+                return false;
+
+            return Bar.Read(inputStream.SetPosition(0))
+                .Any(x => x.Type == Bar.EntryType.RawBitmap);
+        }
+
+        private static IEnumerable<IImageRead> ReadKh2Font(Stream inputStream)
+        {
+            var fontContext = new FontContext();
+            fontContext.Read(Bar.Read(inputStream.SetPosition(0))
+                .Where(x => x.Type == Bar.EntryType.RawBitmap));
+
+            return new[]
+            {
+                fontContext.ImageSystem,
+                fontContext.ImageSystem2,
+                fontContext.ImageEvent,
+                fontContext.ImageEvent2,
+                fontContext.ImageIcon
+            }.Where(x => x != null);
+        }
+
+        private static void WriteKh2Font(Stream outputStream, IEnumerable<IImageRead> images)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Issues fixed:
* Font swizzled in KH2TextEditor (regression from #223, issue mentioned here https://discord.com/channels/409140906625728532/777560811114725407/782359965943857162)
* Text too small in KH2TextEditor (regression from #241, issue mentioned here #287)

Bonus:
* ImageViewer can now open and display correctly a `fontimage.bar` file. The `icon` entry still have messed-up colours. There is currently no save functionality for `fontimage.bar`.