### PR TITLE
Implement: fry fake motion command to OpenKh.Research.Kh2Anim

### DIFF
--- a/OpenKh.Kh2/Mdlx.cs
+++ b/OpenKh.Kh2/Mdlx.cs
@@ -76,5 +76,24 @@ namespace OpenKh.Kh2
         }
 
         public static Mdlx CreateFromMapModel(M4 mapModel) => new Mdlx(mapModel);
+
+        private Mdlx()
+        {
+            SubModels = new List<SubModel>();
+            SubModels.Add(new SubModel
+            {
+                Type = Entity,
+                Bones = new List<Bone>(),
+                DmaChains = new List<DmaChain>(),
+            });
+            SubModels.Add(new SubModel
+            {
+                Type = Shadow,
+                Bones = new List<Bone>(),
+                DmaChains = new List<DmaChain>(),
+            });
+        }
+
+        public static Mdlx CreateModelFromScratch() => new Mdlx();
     }
 }

--- a/OpenKh.Kh2/Motion.cs
+++ b/OpenKh.Kh2/Motion.cs
@@ -187,12 +187,12 @@ namespace OpenKh.Kh2
             public List<BoneAnimationTable> IKHelperAnimation { get; set; }
             public List<TimelineTable> Timeline { get; set; }
             public List<IKChainTable> IKChains { get; set; }
-            public List<UnknownTable8> Table8 { get; internal set; }
-            public List<UnknownTable7> Table7 { get; internal set; }
-            public List<UnknownTable6> Table6 { get; internal set; }
+            public List<UnknownTable8> Table8 { get; set; }
+            public List<UnknownTable7> Table7 { get; set; }
+            public List<UnknownTable6> Table6 { get; set; }
             public List<IKHelperTable> IKHelpers { get; set; }
             public List<JointTable> Joints { get; set; }
-            public FooterTable Footer { get; internal set; }
+            public FooterTable Footer { get; set; }
         }
 
         public class StaticPoseTable
@@ -766,5 +766,36 @@ namespace OpenKh.Kh2
             writer.Write(matrix.M43);
             writer.Write(matrix.M44);
         }
+
+        private Motion(bool isRaw)
+        {
+            IsRaw = isRaw;
+            if (isRaw)
+            {
+                Raw = new RawMotion
+                {
+                    Matrices = new List<Matrix4x4[]>(),
+                };
+            }
+            else
+            {
+                Interpolated = new InterpolatedMotion
+                {
+                    Footer = new FooterTable(),
+                    IKChains = new List<IKChainTable>(),
+                    IKHelperAnimation = new List<BoneAnimationTable>(),
+                    IKHelpers = new List<IKHelperTable>(),
+                    Joints = new List<JointTable>(),
+                    ModelBoneAnimation = new List<BoneAnimationTable>(),
+                    StaticPose = new List<StaticPoseTable>(),
+                    Table6 = new List<UnknownTable6>(),
+                    Table7 = new List<UnknownTable7>(),
+                    Table8 = new List<UnknownTable8>(),
+                    Timeline = new List<TimelineTable>(),
+                };
+            }
+        }
+
+        public static Motion CreateInterpolatedFromScratch() => new Motion(false);
     }
 }

--- a/OpenKh.Research.Kh2Anim/Program.cs
+++ b/OpenKh.Research.Kh2Anim/Program.cs
@@ -3,7 +3,9 @@ using OpenKh.Common;
 using OpenKh.Common.Exceptions;
 using OpenKh.Kh2;
 using OpenKh.Kh2Anim.Mset;
+using OpenKh.Kh2Anim.Mset.Interfaces;
 using OpenKh.Research.Kh2Anim.Models;
+using OpenKh.Research.Kh2Anim.Subcommands;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -17,6 +19,11 @@ namespace OpenKh.Research.Kh2Anim
 {
     [Command("OpenKh.Research.Kh2Anim")]
     [VersionOptionFromMember("--version", MemberName = nameof(GetVersion))]
+    [Subcommand(
+        typeof(BakeCommand),
+        typeof(FryCommand),
+        typeof(SimpleMdlxCommand)
+    )]
     class Program
     {
         static int Main(string[] args)
@@ -42,134 +49,10 @@ namespace OpenKh.Research.Kh2Anim
             }
         }
 
-        [Required]
-        [FileExists]
-        [Argument(0, Description = "Input file: model.mdlx")]
-        public string InputMdlx { get; set; }
-
-        [Required]
-        [FileExists]
-        [Argument(1, Description = "Input file: model.{mset,anb}")]
-        public string InputAnim { get; set; }
-
-        [Argument(2, Description = "XML Output dir")]
-        public string OutputDir { get; set; }
-
-        class AnbBarWrapper
-        {
-            public int IndexInMset { get; set; }
-            public List<Bar.Entry> BarEntries { get; set; }
-        }
-
         protected int OnExecute(CommandLineApplication app)
         {
-            var mdlxBytes = File.ReadAllBytes(InputMdlx);
-
-            OutputDir ??= Path.Combine(Path.GetDirectoryName(InputAnim), Path.GetFileNameWithoutExtension(InputAnim));
-
-            Directory.CreateDirectory(OutputDir);
-
-            var unkBarEntries = File.OpenRead(InputAnim).Using(Bar.Read);
-
-            var anbBarEntriesList = unkBarEntries.Any(entry => entry.Type == Bar.EntryType.Motion)
-                // Input is `.anb`
-                ? new AnbBarWrapper[] {
-                    new AnbBarWrapper {
-                        BarEntries = unkBarEntries,
-                        IndexInMset = 0,
-                    }
-                }
-                // Input is `.mset`
-                : unkBarEntries
-                    .Select(
-                        (msetBarEntry, index) => new AnbBarWrapper
-                        {
-                            IndexInMset = index,
-                            BarEntries = (msetBarEntry.Stream.Length != 0)
-                                ? Bar.Read(msetBarEntry.Stream)
-                                : new List<Bar.Entry>()
-                        }
-                    );
-
-            anbBarEntriesList
-                .ForEach(
-                    wrapper =>
-                    {
-                        var anbIndir = new AnbIndir(wrapper.BarEntries);
-
-                        if (!anbIndir.HasAnimationData)
-                        {
-                            return;
-                        }
-
-                        var provider = anbIndir.GetAnimProvider(
-                            new MemoryStream(mdlxBytes, false)
-                        );
-
-                        var xmlFile = Path.Combine(OutputDir, $"{wrapper.IndexInMset}.xml");
-
-                        var timeArray = Enumerable.Range(0, (int)provider.FrameEnd)
-                            .Select(it => (float)it);
-
-                        var export = new MotionExport
-                        {
-                            FrameCount = provider.FrameCount,
-                            FrameEnd = provider.FrameEnd,
-                            FrameLoop = provider.FrameLoop,
-                            FramePerSecond = provider.FramePerSecond,
-                            MatrixCount = provider.MatrixCount,
-
-                            Frame = timeArray
-                                .Select(
-                                    time =>
-                                    {
-                                        var matrixArray = provider.ProvideMatrices(0);
-                                        return new MotionExport.FrameClass
-                                        {
-                                            Time = time,
-                                            Matrices = MatrixArrayToString(matrixArray),
-                                        };
-                                    }
-                                )
-                                .ToArray(),
-                        };
-
-                        File.Create(xmlFile).Using(
-                            stream => new XmlSerializer(typeof(MotionExport)).Serialize(stream, export)
-                        );
-                    }
-                );
-
-            return 0;
-        }
-
-        private string MatrixArrayToString(Matrix4x4[] matrixArray)
-        {
-            return string.Join(
-                ",",
-                matrixArray
-                    .Select(
-                        matrix => string.Join(
-                            " "
-                            , $"{matrix.M11}"
-                            , $"{matrix.M12}"
-                            , $"{matrix.M13}"
-                            , $"{matrix.M14}"
-                            , $"{matrix.M21}"
-                            , $"{matrix.M22}"
-                            , $"{matrix.M23}"
-                            , $"{matrix.M24}"
-                            , $"{matrix.M31}"
-                            , $"{matrix.M32}"
-                            , $"{matrix.M33}"
-                            , $"{matrix.M34}"
-                            , $"{matrix.M41}"
-                            , $"{matrix.M42}"
-                            , $"{matrix.M43}"
-                            , $"{matrix.M44}"
-                        )
-                    )
-            );
+            app.ShowHelp();
+            return 1;
         }
 
         private static string GetVersion()

--- a/OpenKh.Research.Kh2Anim/Subcommands/BakeCommand.cs
+++ b/OpenKh.Research.Kh2Anim/Subcommands/BakeCommand.cs
@@ -1,0 +1,159 @@
+using McMaster.Extensions.CommandLineUtils;
+using OpenKh.Common;
+using OpenKh.Kh2;
+using OpenKh.Kh2Anim.Mset;
+using OpenKh.Research.Kh2Anim.Models;
+using OpenKh.Research.Kh2Anim.Utils;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace OpenKh.Research.Kh2Anim.Subcommands
+{
+    [HelpOption]
+    [Command(Description = "Bake motion as Matrix4x4, and then write them into xml file")]
+    class BakeCommand
+    {
+        [Required]
+        [FileExists]
+        [Argument(0, Description = "Input file: model.mdlx")]
+        public string InputMdlx { get; set; }
+
+        [Required]
+        [FileExists]
+        [Argument(1, Description = "Input file: model.{mset,anb}")]
+        public string InputAnim { get; set; }
+
+        [Argument(2, Description = "XML Output dir")]
+        public string OutputDir { get; set; }
+
+        [Option(CommandOptionType.SingleValue, Description = "Frames per second")]
+        public float FPS { get; set; } = 0;
+
+        protected int OnExecute(CommandLineApplication app)
+        {
+            var mdlxBytes = File.ReadAllBytes(InputMdlx);
+
+            OutputDir ??= Path.Combine(Path.GetDirectoryName(InputAnim), Path.GetFileNameWithoutExtension(InputAnim));
+
+            Directory.CreateDirectory(OutputDir);
+
+            var unkBarEntries = File.OpenRead(InputAnim).Using(Bar.Read);
+
+            ConvertAnbOrMsetIntoMset(unkBarEntries)
+                .ForEach(
+                    wrapper =>
+                    {
+                        var anbIndir = new AnbIndir(wrapper.BarEntries);
+
+                        if (!anbIndir.HasAnimationData)
+                        {
+                            return;
+                        }
+
+                        var provider = anbIndir.GetAnimProvider(
+                            new MemoryStream(mdlxBytes, false)
+                        );
+
+                        var xmlFile = Path.Combine(OutputDir, $"{wrapper.IndexInMset}.xml");
+
+                        if (FPS == 0)
+                        {
+                            FPS = 30;
+                        }
+
+                        var gameTimeDelta = 1 / FPS;
+
+                        var timeArray = Enumerable.Range(0, (int)(provider.FrameEnd * FPS))
+                            .Select(it => (float)(it * gameTimeDelta));
+
+                        var export = new MotionExport
+                        {
+                            FrameCount = provider.FrameCount,
+                            FrameEnd = provider.FrameEnd,
+                            FrameLoop = provider.FrameLoop,
+                            FramePerSecond = provider.FramePerSecond,
+                            MatrixCount = provider.MatrixCount,
+
+                            Frame = timeArray
+                                .Select(
+                                    time =>
+                                    {
+                                        var matrixArray = provider.ProvideMatrices(gameTimeDelta);
+                                        return new MotionExport.FrameClass
+                                        {
+                                            Time = time,
+                                            Matrices = MatrixArrayToString(matrixArray),
+                                        };
+                                    }
+                                )
+                                .ToArray(),
+                        };
+
+                        File.Create(xmlFile).Using(
+                            stream => new XmlSerializer(typeof(MotionExport)).Serialize(stream, export)
+                        );
+                    }
+                );
+
+            return 0;
+        }
+
+        private string MatrixArrayToString(Matrix4x4[] matrixArray)
+        {
+            return string.Join(
+                ",",
+                matrixArray
+                    .Select(
+                        matrix => string.Join(
+                            " "
+                            , $"{matrix.M11}"
+                            , $"{matrix.M12}"
+                            , $"{matrix.M13}"
+                            , $"{matrix.M14}"
+                            , $"{matrix.M21}"
+                            , $"{matrix.M22}"
+                            , $"{matrix.M23}"
+                            , $"{matrix.M24}"
+                            , $"{matrix.M31}"
+                            , $"{matrix.M32}"
+                            , $"{matrix.M33}"
+                            , $"{matrix.M34}"
+                            , $"{matrix.M41}"
+                            , $"{matrix.M42}"
+                            , $"{matrix.M43}"
+                            , $"{matrix.M44}"
+                        )
+                    )
+            );
+        }
+
+        private static IEnumerable<AnbBarWrapper> ConvertAnbOrMsetIntoMset(IEnumerable<Bar.Entry> unkBarEntries)
+        {
+            return unkBarEntries.Any(entry => entry.Type == Bar.EntryType.Motion)
+                // Input is `.anb`
+                ? new AnbBarWrapper[] {
+                    new AnbBarWrapper {
+                        BarEntries = unkBarEntries.ToList(),
+                        IndexInMset = 0,
+                    }
+                }
+                // Input is `.mset`
+                : unkBarEntries
+                    .Select(
+                        (msetBarEntry, index) => new AnbBarWrapper
+                        {
+                            IndexInMset = index,
+                            BarEntries = (msetBarEntry.Stream.Length != 0)
+                                ? Bar.Read(msetBarEntry.Stream)
+                                : new List<Bar.Entry>()
+                        }
+                    );
+        }
+    }
+}

--- a/OpenKh.Research.Kh2Anim/Subcommands/FryCommand.cs
+++ b/OpenKh.Research.Kh2Anim/Subcommands/FryCommand.cs
@@ -1,0 +1,217 @@
+using McMaster.Extensions.CommandLineUtils;
+using OpenKh.Kh2;
+using OpenKh.Kh2Anim.Mset;
+using OpenKh.Kh2Anim.Mset.Interfaces;
+using OpenKh.Research.Kh2Anim.Models;
+using OpenKh.Research.Kh2Anim.TypeConverters;
+using OpenKh.Research.Kh2Anim.Utils;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using static OpenKh.Kh2.Motion;
+
+namespace OpenKh.Research.Kh2Anim.Subcommands
+{
+    [HelpOption]
+    [Command(Description = "Fry fake motion")]
+    class FryCommand
+    {
+        [Option(CommandOptionType.SingleValue, ShortName = "o", Description = "Output file: model.mset")]
+        public string OutputMset { get; set; }
+
+        [Option(CommandOptionType.SingleValue, ShortName = "l", Description = "Unknown")]
+        public float FrameLoop { get; set; } = 0;
+
+        [Option(CommandOptionType.SingleValue, ShortName = "e", Description = "Unknown")]
+        public float FrameEnd { get; set; } = 100;
+
+        [Option(CommandOptionType.SingleValue, ShortName = "c", Description = "Unknown")]
+        public float FrameCount { get; set; } = 0;
+
+        [Option(CommandOptionType.SingleValue, ShortName = "a", Description = "Unknown")]
+        public int TotalFrameCount { get; set; } = 100;
+
+        [Option(CommandOptionType.SingleValue, ShortName = "f", Description = "FPS")]
+        public float FramePerSecond { get; set; } = 1;
+
+        [Option(CommandOptionType.MultipleValue, ShortName = "t", Description = "Interpolation,FrameTime,Value,TangentEaseIn,TangentEaseOut\n(Nearest|Linear|Hermite|Zero),0.00,0.00,0.00,0.00")]
+        public string[] Timeline { get; set; }
+
+        [Option(CommandOptionType.SingleValue, ShortName = "p", Description = "Output gnuplot file set with this file path prefix")]
+        public string Prefix { get; set; }
+
+        [Option(CommandOptionType.SingleValue, ShortName = "u", Description = "Unknown")]
+        public byte Pre { get; set; } = 0;
+
+        [Option(CommandOptionType.SingleValue, ShortName = "v", Description = "Unknown")]
+        public byte Post { get; set; } = 0;
+
+        [Option(CommandOptionType.SingleValue, ShortName = "n", Description = "StaticPose value")]
+        public float InitialValue { get; set; } = 0;
+
+        [Option(CommandOptionType.SingleValue, ShortName = "m", Description = "The value directly set to matrix")]
+        public float MatrixValue { get; set; } = 0;
+
+        protected int OnExecute(CommandLineApplication app)
+        {
+            FramePerSecond = Math.Max(1, FramePerSecond);
+
+            if (Timeline == null || Timeline?.Length == 0)
+            {
+                Timeline = new string[] { $"Linear,{FrameLoop},0,0,0", $"Linear,{FrameEnd},100,0,0" };
+            }
+
+            var mdlxFile = MdlxMaker.CreateMdlxHaving2Bones(tx: MatrixValue);
+
+            var motion = Motion.CreateInterpolatedFromScratch();
+            var interpolated = motion.Interpolated;
+            interpolated.ModelBoneAnimation.Add(
+                new BoneAnimationTable
+                {
+                    JointIndex = 1,
+                    Channel = (byte)(6 | ((3 & Pre) << 4) | ((3 & Post) << 6)),
+                    TimelineStartIndex = 0,
+                    TimelineCount = Convert.ToByte(Timeline.Length),
+                }
+            );
+            interpolated.BoneCount = 2;
+            interpolated.FrameCount = FrameCount;
+            interpolated.FrameEnd = FrameEnd;
+            interpolated.FrameLoop = FrameLoop;
+            interpolated.FramePerSecond = FramePerSecond;
+            interpolated.StaticPose.Add(
+                new Motion.StaticPoseTable
+                {
+                    BoneIndex = 1,
+                    Channel = 6,
+                    Value = InitialValue,
+                }
+            );
+            interpolated.Joints.Add(new JointTable { JointIndex = 0, });
+            interpolated.Joints.Add(new JointTable { JointIndex = 1, });
+            interpolated.TotalFrameCount = TotalFrameCount;
+            interpolated.Footer.Unknown = new int[9];
+
+            var converter = new TimelineTableConverter();
+
+            interpolated.Timeline.AddRange(
+                (Timeline ?? new string[0])
+                    .Select(text => converter.ConvertFromInvariantString(text))
+                    .Cast<TimelineTable>()
+            );
+
+            var motionBin = new MemoryStream();
+            Motion.Write(motionBin, motion);
+
+            motionBin.Position = 0;
+
+            var anbFile = new MemoryStream();
+
+            var anbBarEntries = new Bar.Entry[]
+            {
+                new Bar.Entry
+                {
+                    Type = Bar.EntryType.Motion,
+                    Stream = motionBin,
+                    Name = "A000",
+                },
+            };
+
+            Bar.Write(
+                anbFile,
+                anbBarEntries
+            );
+
+            anbFile.Position = 0;
+
+            var msetFile = new MemoryStream();
+
+            Bar.Write(
+                msetFile,
+                new Bar.Entry[]
+                {
+                    new Bar.Entry
+                    {
+                        Type = Bar.EntryType.Anb,
+                        Stream = anbFile,
+                        Name = "A000",
+                    },
+                }
+            );
+
+            msetFile.Position = 0;
+
+            if (!string.IsNullOrEmpty(OutputMset))
+            {
+                File.WriteAllBytes(OutputMset, msetFile.ToArray());
+            }
+
+            motionBin.Position = 0;
+
+            var animReader = new AnimReader(motionBin);
+
+            mdlxFile.Position = 0;
+
+            var outFiles = new Dictionary<string, object>();
+
+            {
+                var dat = new StringWriter();
+                var gnuplot = new StringWriter();
+                gnuplot.WriteLine($"set terminal png");
+                gnuplot.WriteLine($"set title '{Prefix}'");
+                gnuplot.WriteLine($"set output '{Prefix}.png'");
+                gnuplot.WriteLine($"plot '{Prefix}.dat' index 0 title 'out' with lines, \\");
+                gnuplot.WriteLine($"     '' index 1 title 'in' with points");
+
+                outFiles[$"{Prefix}.dat"] = dat;
+                outFiles[$"{Prefix}.txt"] = gnuplot;
+
+                var provider = (IAnimMatricesProvider)new EmuBasedAnimMatricesProvider(animReader, mdlxFile, motionBin);
+
+                dat.WriteLine("# X Y");
+
+                foreach (var x in Enumerable.Range(0, (int)((FrameEnd - FrameLoop + 1) * FramePerSecond)))
+                {
+                    var matrices = provider.ProvideMatrices((x == 0) ? 0 : 1);
+
+                    var xVal = FrameLoop + (x / FramePerSecond);
+                    var yVal = matrices[1].M41;
+
+                    dat.WriteLine($"{xVal} {yVal}");
+                }
+
+                dat.WriteLine();
+                dat.WriteLine();
+
+                dat.WriteLine("# X Y");
+
+                interpolated.Timeline
+                    .ForEach(
+                        indir =>
+                        {
+                            dat.WriteLine($"{indir.KeyFrame} {indir.Value}");
+                        }
+                    );
+            }
+
+            if (!string.IsNullOrEmpty(Prefix))
+            {
+                outFiles.ForEach(
+                    pair => File.WriteAllText(
+                        pair.Key,
+                        "" + pair.Value,
+                        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)
+                    )
+                );
+
+                Console.WriteLine($"Run: gnuplot {Prefix}.txt");
+            }
+
+            return 0;
+        }
+
+    }
+}

--- a/OpenKh.Research.Kh2Anim/Subcommands/SimpleMdlxCommand.cs
+++ b/OpenKh.Research.Kh2Anim/Subcommands/SimpleMdlxCommand.cs
@@ -1,0 +1,25 @@
+using McMaster.Extensions.CommandLineUtils;
+using OpenKh.Research.Kh2Anim.Utils;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Text;
+
+namespace OpenKh.Research.Kh2Anim.Subcommands
+{
+    [HelpOption]
+    [Command(Description = "Create mdlx having 2 bones")]
+    class SimpleMdlxCommand
+    {
+        [Required]
+        [Argument(0, Description = "Output file: model.mdlx")]
+        public string OutputMdlx { get; set; }
+
+        protected int OnExecute(CommandLineApplication app)
+        {
+            File.WriteAllBytes(OutputMdlx, MdlxMaker.CreateMdlxHaving2Bones().ToArray());
+            return 0;
+        }
+    }
+}

--- a/OpenKh.Research.Kh2Anim/TypeConverters/TimelineTableConverter.cs
+++ b/OpenKh.Research.Kh2Anim/TypeConverters/TimelineTableConverter.cs
@@ -1,0 +1,37 @@
+using OpenKh.Kh2;
+using OpenKh.Research.Kh2Anim.Models;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using static OpenKh.Kh2.Motion;
+
+namespace OpenKh.Research.Kh2Anim.TypeConverters
+{
+    class TimelineTableConverter : TypeConverter
+    {
+        public TimelineTableConverter()
+        {
+
+        }
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            var tokens = (value + "").Split(',');
+            return new TimelineTable
+            {
+                Interpolation = (Interpolation)Enum.Parse(typeof(Interpolation), tokens[0], true),
+                KeyFrame = Convert.ToSingle(tokens[1]),
+                Value = Convert.ToSingle(tokens[2]),
+                TangentEaseIn = Convert.ToSingle(tokens[3]),
+                TangentEaseOut = Convert.ToSingle(tokens[4]),
+            };
+        }
+    }
+}

--- a/OpenKh.Research.Kh2Anim/Utils/AnbBarWrapper.cs
+++ b/OpenKh.Research.Kh2Anim/Utils/AnbBarWrapper.cs
@@ -1,0 +1,13 @@
+using OpenKh.Kh2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenKh.Research.Kh2Anim.Utils
+{
+    class AnbBarWrapper
+    {
+        public int IndexInMset { get; set; }
+        public List<Bar.Entry> BarEntries { get; set; }
+    }
+}

--- a/OpenKh.Research.Kh2Anim/Utils/MdlxMaker.cs
+++ b/OpenKh.Research.Kh2Anim/Utils/MdlxMaker.cs
@@ -1,0 +1,61 @@
+using OpenKh.Kh2;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace OpenKh.Research.Kh2Anim.Utils
+{
+    static class MdlxMaker
+    {
+        internal static MemoryStream CreateMdlxHaving2Bones(float tx = 0)
+        {
+            var model = Mdlx.CreateModelFromScratch();
+
+            model.SubModels[0].BoneCount = 2;
+            model.SubModels[0].Bones.Add(
+                new Mdlx.Bone
+                {
+                    Index = 0,
+                    Parent = -1,
+                    ScaleX = 1,
+                    ScaleY = 1,
+                    ScaleZ = 1,
+                    ScaleW = 1,
+                }
+            );
+            model.SubModels[0].Bones.Add(
+                new Mdlx.Bone
+                {
+                    Index = 1,
+                    Parent = 0,
+                    ScaleX = 1,
+                    ScaleY = 1,
+                    ScaleZ = 1,
+                    ScaleW = 1,
+                    TranslationX = tx,
+                }
+            );
+
+            var modelBin = new MemoryStream();
+            model.Write(modelBin);
+
+            var mdlxFile = new MemoryStream();
+
+            Bar.Write(
+                mdlxFile,
+                new Bar.Entry[]
+                {
+                        new Bar.Entry
+                        {
+                            Type = Bar.EntryType.Model,
+                            Stream = modelBin,
+                            Name = "p_ex",
+                        },
+                }
+            );
+
+            return mdlxFile;
+        }
+    }
+}

--- a/OpenKh.sln
+++ b/OpenKh.sln
@@ -143,7 +143,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Pipelines", "Pipelines", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Kh2AnimEmu", "OpenKh.Kh2AnimEmu\OpenKh.Kh2AnimEmu.csproj", "{DBDBCB21-AD60-4344-9E9A-600E1D36C845}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenKh.Research.Kh2Anim", "OpenKh.Research.Kh2Anim\OpenKh.Research.Kh2Anim.csproj", "{D4AF702B-145A-4052-B347-15166C43AB3F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenKh.Research.Kh2Anim", "OpenKh.Research.Kh2Anim\OpenKh.Research.Kh2Anim.csproj", "{D4AF702B-145A-4052-B347-15166C43AB3F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
**Note:** this pr contains merged codes from https://github.com/Xeeynamo/OpenKh/pull/310

Usage:

```
$ ./OpenKh.Research.Kh2Anim.exe fry -h
Fry fake motion

Usage: OpenKh.Research.Kh2Anim fry [options]

Options:
  -?|-h|--help                                Show help information
  -o|--output-mset <OUTPUT_MSET>              Output file: model.mset
  -l|--frame-loop <FRAME_LOOP>                Unknown
  -e|--frame-end <FRAME_END>                  Unknown
  -c|--frame-count <FRAME_COUNT>              Unknown
  -a|--total-frame-count <TOTAL_FRAME_COUNT>  Unknown
  -f|--frame-per-second <FRAME_PER_SECOND>    FPS
  -t|--timeline <TIMELINE>                    Interpolation,FrameTime,Value,TangentEaseIn,TangentEaseOut
                                              (Nearest|Linear|Hermite|Zero),0.00,0.00,0.00,0.00
  -p|--prefix <PREFIX>                        Output gnuplot file set with this file path prefix
  -u|--pre <PRE>                              Unknown
  -v|--post <POST>                            Unknown
  -n|--initial-value <INITIAL_VALUE>          StaticPose value
  -m|--matrix-value <MATRIX_VALUE>            The value directly set to matrix

```

Sample:

```sh
#!/bin/bash
set -eux

function plotWith() {
  ./OpenKh.Research.Kh2Anim.exe fry \
    --prefix $1 \
    --output-mset $1.mset \
    --matrix-value 20 \
    --initial-value 50 \
    --pre 1 \
    --post 1 \
    --timeline "$1,10,0,0,0" \
    --timeline "$1,25,50,0,0" \
    --timeline "$1,50,100,0,0" \
    --timeline "$1,75,50,0,0" \
    --timeline "$1,90,0,0,0"
  gnuplot $1.txt
}

plotWith "nearest"
plotWith "linear"
plotWith "hermite"
plotWith "zero"
```