### PR TITLE
Fix fontimage swizzling.

### DIFF
--- a/OpenKh.Kh2/RawBitmap.cs
+++ b/OpenKh.Kh2/RawBitmap.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.IO;
 using OpenKh.Imaging;
@@ -30,7 +30,9 @@ namespace OpenKh.Kh2
             var reader = new BinaryReader(stream);
             var bpp = is8bit ? 8 : 4;
             _data = reader.ReadBytes(width * height * bpp / 8);
-            ImageDataHelpers.SwapEndianIndexed4(_data);
+
+            if (bpp == 4)
+                ImageDataHelpers.SwapEndianIndexed4(_data);
 
             // If we did not reached the end of the stream, then it does mean that there is a palette
             if (stream.Position < stream.Length)


### PR DESCRIPTION
This PR fixes an oversight with RawBitmap swizzling where it applied a fix for 4bpp images to 8bpp images also.

This PR has been tested with everything except for OpenKH.Game and is functional.

Demo Images:
![image](https://user-images.githubusercontent.com/28973970/102710936-20bb4100-42c7-11eb-8805-a06ba90f6834.png)
![image](https://user-images.githubusercontent.com/28973970/102710958-4cd6c200-42c7-11eb-8e17-199dd4edb29f.png)
![image](https://user-images.githubusercontent.com/28973970/102710967-5c560b00-42c7-11eb-9731-a63eb2049cea.png)

And here are IMGDs that I have tested (Swizzled and non-swizzled):
![image](https://user-images.githubusercontent.com/28973970/102710978-72fc6200-42c7-11eb-908a-d3b12fb114d1.png)
![image](https://user-images.githubusercontent.com/28973970/102710986-798ad980-42c7-11eb-9250-78ed9e21704c.png)
