### PR TITLE
Rename namespace + fix CRLF to LF

### DIFF
--- a/OpenKh.Game/Infrastructure/Kernel.cs
+++ b/OpenKh.Game/Infrastructure/Kernel.cs
@@ -8,7 +8,7 @@ using OpenKh.Kh2;
 using OpenKh.Kh2.Battle;
 using OpenKh.Kh2.Contextes;
 using OpenKh.Kh2.Extensions;
-using OpenKh.Kh2.System;
+using OpenKh.Kh2.SystemData;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -118,9 +118,9 @@ namespace OpenKh.Game.Infrastructure
         {
             var bar = DataContent.FileOpen(fileName).Using(stream => Bar.Read(stream));
 
-            Ftst = bar.ForEntry("ftst", Bar.EntryType.List, Kh2.System.Ftst.Read);
-            Item = bar.ForEntry("item", Bar.EntryType.List, Kh2.System.Item.Read);
-            Trsr = bar.ForEntry("tsrs", Bar.EntryType.List, Kh2.System.Trsr.Read);
+            Ftst = bar.ForEntry("ftst", Bar.EntryType.List, Kh2.SystemData.Ftst.Read);
+            Item = bar.ForEntry("item", Bar.EntryType.List, Kh2.SystemData.Item.Read);
+            Trsr = bar.ForEntry("tsrs", Bar.EntryType.List, Kh2.SystemData.Trsr.Read);
         }
 
         private void LoadBattle(string fileName)

--- a/OpenKh.Kh2/Contextes/FontContext.cs
+++ b/OpenKh.Kh2/Contextes/FontContext.cs
@@ -1,5 +1,5 @@
-﻿using OpenKh.Imaging;
-using OpenKh.Kh2.System;
+using OpenKh.Imaging;
+using OpenKh.Kh2.SystemData;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/OpenKh.Kh2/SystemData/Ftst.cs
+++ b/OpenKh.Kh2/SystemData/Ftst.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Xe.BinaryMapper;
 
-namespace OpenKh.Kh2.System
+namespace OpenKh.Kh2.SystemData
 {
     public class Ftst
     {

--- a/OpenKh.Kh2/SystemData/Item.cs
+++ b/OpenKh.Kh2/SystemData/Item.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Xe.BinaryMapper;
 
-namespace OpenKh.Kh2.System
+namespace OpenKh.Kh2.SystemData
 {
     public class Item
     {

--- a/OpenKh.Kh2/SystemData/Trsr.cs
+++ b/OpenKh.Kh2/SystemData/Trsr.cs
@@ -1,9 +1,8 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Xe.BinaryMapper;
 
-namespace OpenKh.Kh2.System
+namespace OpenKh.Kh2.SystemData
 {
     public class Trsr
     {

--- a/OpenKh.Tests/kh2/System03Tests.cs
+++ b/OpenKh.Tests/kh2/System03Tests.cs
@@ -1,5 +1,5 @@
 using OpenKh.Common;
-using OpenKh.Kh2.System;
+using OpenKh.Kh2.SystemData;
 using System.IO;
 using Xunit;
 

--- a/OpenKh.Tools.Kh2SystemEditor/Models/Export/ItemExport.cs
+++ b/OpenKh.Tools.Kh2SystemEditor/Models/Export/ItemExport.cs
@@ -1,5 +1,5 @@
-﻿using OpenKh.Engine;
-using OpenKh.Kh2.System;
+using OpenKh.Engine;
+using OpenKh.Kh2.SystemData;
 using OpenKh.Tools.Kh2SystemEditor.Attributes;
 using System;
 using System.Collections.Generic;

--- a/OpenKh.Tools.Kh2SystemEditor/Models/Export/TrsrExport.cs
+++ b/OpenKh.Tools.Kh2SystemEditor/Models/Export/TrsrExport.cs
@@ -1,5 +1,5 @@
-﻿using OpenKh.Kh2;
-using OpenKh.Kh2.System;
+using OpenKh.Kh2;
+using OpenKh.Kh2.SystemData;
 using OpenKh.Tools.Kh2SystemEditor.Attributes;
 using OpenKh.Tools.Kh2SystemEditor.Interfaces;
 using System;

--- a/OpenKh.Tools.Kh2SystemEditor/ViewModels/FtstViewModel.cs
+++ b/OpenKh.Tools.Kh2SystemEditor/ViewModels/FtstViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,7 +6,7 @@ using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
 using OpenKh.Kh2;
-using OpenKh.Kh2.System;
+using OpenKh.Kh2.SystemData;
 using OpenKh.Tools.Common;
 using OpenKh.Tools.Common.Models;
 using OpenKh.Tools.Kh2SystemEditor.Extensions;

--- a/OpenKh.Tools.Kh2SystemEditor/ViewModels/ItemViewModel.cs
+++ b/OpenKh.Tools.Kh2SystemEditor/ViewModels/ItemViewModel.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows;
 using OpenKh.Engine;
 using OpenKh.Kh2;
-using OpenKh.Kh2.System;
+using OpenKh.Kh2.SystemData;
 using OpenKh.Tools.Common.Models;
 using OpenKh.Tools.Kh2SystemEditor.Extensions;
 using OpenKh.Tools.Kh2SystemEditor.Interfaces;

--- a/OpenKh.Tools.Kh2SystemEditor/ViewModels/SystemEditorViewModel.cs
+++ b/OpenKh.Tools.Kh2SystemEditor/ViewModels/SystemEditorViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,7 +14,7 @@ using Xe.Tools.Wpf.Dialogs;
 using OpenKh.Tools.Kh2SystemEditor.Interfaces;
 using OpenKh.Engine;
 using OpenKh.Tools.Kh2SystemEditor.Utils;
-using OpenKh.Kh2.System;
+using OpenKh.Kh2.SystemData;
 using OpenKh.Kh2.Messages;
 using OpenKh.Tools.Kh2SystemEditor.Models.Export;
 

--- a/OpenKh.Tools.Kh2SystemEditor/ViewModels/TrsrViewModel.cs
+++ b/OpenKh.Tools.Kh2SystemEditor/ViewModels/TrsrViewModel.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows;
 using OpenKh.Kh2;
-using OpenKh.Kh2.System;
+using OpenKh.Kh2.SystemData;
 using OpenKh.Tools.Common.Models;
 using OpenKh.Tools.Kh2SystemEditor.Extensions;
 using OpenKh.Tools.Kh2SystemEditor.Interfaces;


### PR DESCRIPTION
We currently have a namespace called `OpenKh.Kh2.System`, where all the structures from `00system.bin` and `03system.bin` are. The biggest problem is that if you import the namespace `using OpenKh.Kh2;`, you can not use anything anymore from the namespace `System`, which contains the fundamentals of .NET.

This PR renames it into `OpenKh.Kh2.SystemData`, fixing the issue. As we are now using `LF` instead of `CRLF`, I converted the files that have been changed to `LF` to keep consistency.