### PR TITLE
Workaround for broken mset motion data

### DIFF
--- a/OpenKh.Kh2/Motion.cs
+++ b/OpenKh.Kh2/Motion.cs
@@ -1,4 +1,5 @@
 using OpenKh.Common;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -505,8 +506,8 @@ namespace OpenKh.Kh2
                     .Select(x => new TimelineTable
                     {
                         Interpolation = (Interpolation)(x.Time & 3),
-                        KeyFrame = keyFrames[x.Time >> 2],
-                        Value = transformationValues[x.ValueIndex],
+                        KeyFrame = keyFrames[Math.Min(keyFrames.Count - 1, x.Time >> 2)],
+                        Value = transformationValues[Math.Min(transformationValues.Count - 1, x.ValueIndex)],
                         TangentEaseIn = tangentValues[x.TangentIndexEaseIn],
                         TangentEaseOut = tangentValues[x.TangentIndexEaseOut],
                     })

--- a/OpenKh.Tests/Imaging/Tm2Tests.cs
+++ b/OpenKh.Tests/Imaging/Tm2Tests.cs
@@ -1,4 +1,4 @@
-﻿using OpenKh.Common;
+using OpenKh.Common;
 using OpenKh.Imaging;
 using OpenKh.Kh2;
 using System;
@@ -64,7 +64,7 @@ namespace OpenKh.Tests.Imaging
         /// </remarks>
         [Theory]
         [InlineData("Imaging/res")]
-        //[InlineData(@"H:\KH2fm.OpenKH\map\jp")]
+        //[InlineData(".tests/kh2_data/map/jp")]
         public void ValidateAllKH2MapRadarImages(string mapFilesDir)
         {
             Directory.GetFiles(mapFilesDir, "*.map").ToList().ForEach(

--- a/OpenKh.Tests/kh2/MotionTests.cs
+++ b/OpenKh.Tests/kh2/MotionTests.cs
@@ -76,7 +76,7 @@ namespace OpenKh.Tests.kh2
 
         public class UseAssetAnbFiles
         {
-            private static string KH2Dir = @"H:\KH2fm.OpenKh\";
+            private static string KH2Dir = ".tests/kh2_data/";
 
             public static IEnumerable<object[]> Source()
             {
@@ -107,7 +107,7 @@ namespace OpenKh.Tests.kh2
 
         public class UseAssetMsetFiles
         {
-            private static string KH2Dir = @"H:\KH2fm.OpenKh\";
+            private static string KH2Dir = ".tests/kh2_data/";
 
             public static IEnumerable<object[]> Source()
             {


### PR DESCRIPTION
Workaround for broken mset motion data that is pointing to overflowed index of keyFrames and transformationValues.

To enable xunit batch test, set `KH2Dir` to valid path to asset files extracted by extractor:

```cs
private static string KH2Dir = @"H:\KH2fm.OpenKh\";
```

and uncomment:

```cs
//[Theory, MemberData(nameof(Source))]
```

And then build and run tests.

![image](https://user-images.githubusercontent.com/5955540/103166231-516d1e80-4863-11eb-9946-e86c351604c0.png)
