### PR TITLE
Add a dialog to inform missing PngQuant on ImageViewer.

### DIFF
--- a/OpenKh.Tools.ImageViewer/ViewModels/ImageViewerViewModel.cs
+++ b/OpenKh.Tools.ImageViewer/ViewModels/ImageViewerViewModel.cs
@@ -294,6 +294,24 @@ namespace OpenKh.Tools.ImageViewer.ViewModels
                 x => IsMultipleImageFormat && ImageContainer.Count >= 1
             );
 
+            CheckQuant = new RelayCommand(x =>
+            {
+                if (UsePngquant == true)
+                {
+                    if (!File.Exists("pngquant.exe"))
+                    {
+                        UsePngquant = false;
+
+                        string _msg = "PNGQuant was not located in OpenKH's root folder.\n" +
+                                       "Please acquire PNGQuant from the link below and\n" +
+                                       "place it in the same folder as this viewer.";
+
+                        new MessageDialog(_msg, "https://pngquant.org/pngquant-windows.zip").ShowDialog();
+                        OnPropertyChanged(nameof(UsePngquant));
+                    }
+                }
+            });
+
             ZoomLevel = ZoomLevelFit;
         }
 
@@ -329,6 +347,8 @@ namespace OpenKh.Tools.ImageViewer.ViewModels
         }
 
         public RelayCommand OpenCommand { get; set; }
+        public RelayCommand CheckQuant { get; set; }
+
         public RelayCommand SaveCommand { get; set; }
         public RelayCommand SaveAsCommand { get; set; }
         public RelayCommand ExitCommand { get; set; }

--- a/OpenKh.Tools.ImageViewer/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ImageViewer/Views/MainWindow.xaml
@@ -38,7 +38,7 @@
                 <MenuItem Header="Convert to 4-bpp image" Command="{Binding ConvertBitsPerPixelCommand}" CommandParameter="4"/>
                 <MenuItem Header="Convert to 8-bpp image" Command="{Binding ConvertBitsPerPixelCommand}" CommandParameter="8"/>
                 <Separator/>
-                <MenuItem Header="Use pngquant" IsChecked="{Binding UsePngquant}" IsCheckable="True" />
+                <MenuItem Header="Use pngquant" IsChecked="{Binding UsePngquant}" Command="{Binding CheckQuant}" IsCheckable="True" />
                 <Separator/>
                 <MenuItem Header="Remove current image" Command="{Binding RemoveImageCommand}"/>
                 <Separator/>


### PR DESCRIPTION
Addresses issue #331. The requested method requires Xe.Tools.Wpf to be edited, with the addition of the files in this archive:
[XE_MessageDialog.zip](https://github.com/Xeeynamo/OpenKh/files/5752958/XE_MessageDialog.zip)

I can also do this with standard WPF DialogBoxes, I think. But since this was the way that was requested, I have done it like so.
Also discovered an issue with Xe.Tools.Wpf. Will be making an issue about the bug.

Preview Image:
![image](https://user-images.githubusercontent.com/28973970/103328141-a29a2f80-4a68-11eb-9d80-68e4f40e2e6d.png)
