### PR TITLE
KH2 Text Editor improvements

### DIFF
--- a/OpenKh.Engine/Renders/Kh2MessageRenderer.cs
+++ b/OpenKh.Engine/Renders/Kh2MessageRenderer.cs
@@ -119,8 +119,6 @@ namespace OpenKh.Engine.Renders
                 context.Scale = command.TextScale;
             else if (command.Command == MessageCommand.Tabulation)
                 context.x += 16; // TODO this is not the real tabulation size
-            else if (command.Command == MessageCommand.NewLine)
-                context.NewLine(_msgContext.FontHeight);
 
             context.Width = Math.Max(context.Width, context.x);
             context.Height = Math.Max(context.Height, context.y + _msgContext.FontHeight * context.Scale);
@@ -171,6 +169,11 @@ namespace OpenKh.Engine.Renders
                 else if (ch == 1)
                 {
                     spacing = 6;
+                }
+                else if (ch == 2)
+                {
+                    context.NewLine(_msgContext.FontHeight);
+                    spacing = 0;
                 }
                 else
                 {

--- a/OpenKh.Game/Debugging/DebugOverlay.cs
+++ b/OpenKh.Game/Debugging/DebugOverlay.cs
@@ -147,7 +147,8 @@ namespace OpenKh.Game.Debugging
             {
                 new MessageCommandModel()
                 {
-                    Command = MessageCommand.NewLine,
+                    Command = MessageCommand.PrintText,
+                    Text = "\n"
                 }
             }));
         }

--- a/OpenKh.Kh2/Messages/Internals/InternationalSystemDecode.cs
+++ b/OpenKh.Kh2/Messages/Internals/InternationalSystemDecode.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace OpenKh.Kh2.Messages.Internals
@@ -11,7 +11,7 @@ namespace OpenKh.Kh2.Messages.Internals
         {
             [0x00] = new SimpleCmdModel(MessageCommand.End),
             [0x01] = new TextCmdModel(' '),
-            [0x02] = new SimpleCmdModel(MessageCommand.NewLine),
+            [0x02] = new TextCmdModel('\n'),
             [0x03] = new SimpleCmdModel(MessageCommand.Reset),
             [0x04] = new SingleDataCmdModel(MessageCommand.Theme),
             [0x05] = new DataCmdModel(MessageCommand.Unknown05, 6),

--- a/OpenKh.Kh2/Messages/Internals/InternationalSystemEncode.cs
+++ b/OpenKh.Kh2/Messages/Internals/InternationalSystemEncode.cs
@@ -1,4 +1,4 @@
-﻿using OpenKh.Common.Exceptions;
+using OpenKh.Common.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/OpenKh.Kh2/Messages/Internals/JapaneseEventDecode.cs
+++ b/OpenKh.Kh2/Messages/Internals/JapaneseEventDecode.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace OpenKh.Kh2.Messages.Internals
 {
@@ -8,7 +8,7 @@ namespace OpenKh.Kh2.Messages.Internals
         {
             [0x00] = new SimpleCmdModel(MessageCommand.End),
             [0x01] = new TextCmdModel(' '),
-            [0x02] = new SimpleCmdModel(MessageCommand.NewLine),
+            [0x02] = new TextCmdModel('\n'),
             [0x03] = new SimpleCmdModel(MessageCommand.Reset),
             [0x04] = new SingleDataCmdModel(MessageCommand.Theme),
             [0x05] = new DataCmdModel(MessageCommand.Unknown05, 6),

--- a/OpenKh.Kh2/Messages/Internals/JapaneseSystemDecode.cs
+++ b/OpenKh.Kh2/Messages/Internals/JapaneseSystemDecode.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace OpenKh.Kh2.Messages.Internals
 {
@@ -8,7 +8,7 @@ namespace OpenKh.Kh2.Messages.Internals
         {
             [0x00] = new SimpleCmdModel(MessageCommand.End),
             [0x01] = new TextCmdModel(' '),
-            [0x02] = new SimpleCmdModel(MessageCommand.NewLine),
+            [0x02] = new TextCmdModel('\n'),
             [0x03] = new SimpleCmdModel(MessageCommand.Reset),
             [0x04] = new SingleDataCmdModel(MessageCommand.Theme),
             [0x05] = new DataCmdModel(MessageCommand.Unknown05, 6),

--- a/OpenKh.Kh2/Messages/Internals/TurkishSystemDecode.cs
+++ b/OpenKh.Kh2/Messages/Internals/TurkishSystemDecode.cs
@@ -11,7 +11,7 @@ namespace OpenKh.Kh2.Messages.Internals
         {
             [0x00] = new SimpleCmdModel(MessageCommand.End),
             [0x01] = new TextCmdModel(' '),
-            [0x02] = new SimpleCmdModel(MessageCommand.NewLine),
+            [0x02] = new TextCmdModel('\n'),
             [0x03] = new SimpleCmdModel(MessageCommand.Reset),
             [0x04] = new SingleDataCmdModel(MessageCommand.Theme),
             [0x05] = new DataCmdModel(MessageCommand.Unknown05, 6),

--- a/OpenKh.Kh2/Messages/MessageCommand.cs
+++ b/OpenKh.Kh2/Messages/MessageCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace OpenKh.Kh2.Messages
+namespace OpenKh.Kh2.Messages
 {
     public enum MessageCommand
     {
@@ -6,7 +6,6 @@
         PrintText,
         PrintComplex,
         Tabulation,
-        NewLine,
         Reset,
         Theme,
         Unknown05,

--- a/OpenKh.Kh2/Messages/MsgSerializer.Text.cs
+++ b/OpenKh.Kh2/Messages/MsgSerializer.Text.cs
@@ -1,4 +1,4 @@
-﻿using OpenKh.Common.Exceptions;
+using OpenKh.Common.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -24,8 +24,6 @@ namespace OpenKh.Kh2.Messages
                 return entry.Text;
             if (entry.Command == MessageCommand.PrintComplex)
                 return $"{{{entry.Text}}}";
-            if (entry.Command == MessageCommand.NewLine)
-                return "\n";
             if (entry.Command == MessageCommand.Tabulation)
                 return "\t";
 
@@ -51,14 +49,7 @@ namespace OpenKh.Kh2.Messages
                 MessageCommandModel messageCommand;
 
                 var ch = value[i++];
-                if (ch == '\n')
-                {
-                    messageCommand = new MessageCommandModel
-                    {
-                        Command = MessageCommand.NewLine,
-                    };
-                }
-                else if (ch == '\t')
+                if (ch == '\t')
                 {
                     messageCommand = new MessageCommandModel
                     {

--- a/OpenKh.Kh2/Messages/MsgSerializer.cs
+++ b/OpenKh.Kh2/Messages/MsgSerializer.cs
@@ -44,11 +44,6 @@ namespace OpenKh.Kh2.Messages
             },
             new SerializerModel
             {
-                Name = "newline",
-                Command = MessageCommand.NewLine,
-            },
-            new SerializerModel
-            {
                 Name = "reset",
                 Command = MessageCommand.Reset,
             },

--- a/OpenKh.Tests/kh2/MsgEncoderTests.cs
+++ b/OpenKh.Tests/kh2/MsgEncoderTests.cs
@@ -1,4 +1,4 @@
-﻿using OpenKh.Kh2.Messages;
+using OpenKh.Kh2.Messages;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -7,6 +7,14 @@ namespace OpenKh.Tests.kh2
 {
     public class MsgEncoderTests
     {
+        public enum EncoderType
+        {
+            InternationalSystem,
+            JapaneseEvent,
+            JapaneseSystem,
+            TurkishSystem
+        };
+
         [Fact]
         public void DecodeTextCorrectly()
         {
@@ -69,7 +77,6 @@ namespace OpenKh.Tests.kh2
         }
 
         [Theory]
-        [InlineData(0x02, "0123456789")]
         [InlineData(0x03, "0123456789")]
         [InlineData(0x04, "123456789")]
         [InlineData(0x05, "6789")]
@@ -253,6 +260,52 @@ namespace OpenKh.Tests.kh2
                 Assert.Equal(new byte[] { command }, encoded);
             else
                 Assert.Equal(new byte[] { command, data }, encoded);
+        }
+
+        [Theory]
+        [InlineData(EncoderType.InternationalSystem)]
+        [InlineData(EncoderType.JapaneseEvent)]
+        [InlineData(EncoderType.JapaneseSystem)]
+        [InlineData(EncoderType.TurkishSystem)]
+        public void EncodeNewLineCharacterCorrectly(EncoderType encoderType)
+        {
+            var encoder = new IMessageEncode[]
+            {
+                Encoders.InternationalSystem,
+                Encoders.JapaneseEvent,
+                Encoders.JapaneseSystem,
+                Encoders.TurkishSystem
+            }[(int)encoderType];
+
+            var encoded = encoder.Encode(new List<MessageCommandModel>
+            {
+                new MessageCommandModel
+                {
+                    Command = MessageCommand.PrintText,
+                    Text = "HE\nLLO",
+                }
+            });
+            Assert.Equal(new byte[] { 0x35, 0x32, 0x02, 0x39, 0x39, 0x3C }, encoded);
+        }
+
+        [Theory]
+        [InlineData(EncoderType.InternationalSystem)]
+        [InlineData(EncoderType.JapaneseEvent)]
+        [InlineData(EncoderType.JapaneseSystem)]
+        [InlineData(EncoderType.TurkishSystem)]
+        public void DecodeNewLineCharacterCorrectly(EncoderType encoderType)
+        {
+            var decoder = new IMessageDecode[]
+            {
+                Encoders.InternationalSystem,
+                Encoders.JapaneseEvent,
+                Encoders.JapaneseSystem,
+                Encoders.TurkishSystem
+            }[(int)encoderType];
+
+            var models = decoder.Decode(new byte[] { 0x35, 0x32, 0x02, 0x39, 0x39, 0x3C });
+            Assert.Single(models);
+            Assert.Equal("HE\nLLO", models[0].Text);
         }
 
         [Theory]

--- a/OpenKh.Tests/kh2/MsgSerializerTests.cs
+++ b/OpenKh.Tests/kh2/MsgSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿using OpenKh.Common.Exceptions;
+using OpenKh.Common.Exceptions;
 using OpenKh.Kh2.Messages;
 using System.IO;
 using System.Linq;
@@ -43,12 +43,7 @@ namespace OpenKh.Tests.kh2
                 new MessageCommandModel
                 {
                     Command = MessageCommand.PrintText,
-                    Text = " complex!"
-                },
-                new MessageCommandModel
-                {
-                    Command = MessageCommand.NewLine,
-                    Text = " complex!"
+                    Text = " complex!\n"
                 },
             };
 
@@ -181,10 +176,7 @@ namespace OpenKh.Tests.kh2
         {
             var commands = MsgSerializer.DeserializeText("hello\nworld!").ToArray();
             Assert.Equal(MessageCommand.PrintText, commands[0].Command);
-            Assert.Equal("hello", commands[0].Text);
-            Assert.Equal(MessageCommand.NewLine, commands[1].Command);
-            Assert.Equal(MessageCommand.PrintText, commands[2].Command);
-            Assert.Equal("world!", commands[2].Text);
+            Assert.Equal("hello\nworld!", commands[0].Text);
         }
 
         [Fact]

--- a/OpenKh.Tools.Kh2TextEditor/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.Kh2TextEditor/ViewModels/MainViewModel.cs
@@ -246,6 +246,9 @@ namespace OpenKh.Tools.Kh2TextEditor.ViewModels
             }
 
             FileName = fileName;
+            LoadSupportFiles(Path.GetDirectoryName(fileName));
+            AutodetectRegion();
+
             return true;
         });
 
@@ -430,6 +433,46 @@ namespace OpenKh.Tools.Kh2TextEditor.ViewModels
                 .ForEntry(Bar.EntryType.List, _barEntryName, 0, entry => WriteMsg(entry.Stream));
 
             Bar.Write(stream, newEntries);
+        }
+
+        private void LoadSupportFiles(string basePath)
+        {
+            const string FontImageFileName = "fontimage.bar";
+            var fontImageFileName = Path.Combine(basePath, FontImageFileName);
+            if (File.Exists(fontImageFileName))
+                OpenFontImageFile(fontImageFileName);
+
+            const string FontInfoFileName = "fontinfo.bar";
+            var fontInfoFileName = Path.Combine(basePath, FontInfoFileName);
+            if (File.Exists(fontInfoFileName))
+                OpenFontImageFile(fontInfoFileName);
+        }
+
+        private void AutodetectRegion()
+        {
+            switch (IsMsgJapanese())
+            {
+                case true:
+                    EncodingType = EncodingType.Japanese;
+                    break;
+                case false:
+                    EncodingType = EncodingType.European;
+                    break;
+            }
+        }
+
+        private bool? IsMsgJapanese()
+        {
+            const ushort FakeTextId = 0x0ADC;
+            if (TextEditor?.MessageEntries == null)
+                return null;
+
+            var messageEntry = TextEditor.MessageEntries.FirstOrDefault(x => x.Id == FakeTextId);
+            var data = messageEntry?.Data;
+            if (data == null || data.Length == 0)
+                return null;
+
+            return data.Length != 5;
         }
     }
 }

--- a/OpenKh.Tools.Kh2TextEditor/ViewModels/TextEditorViewModel.cs
+++ b/OpenKh.Tools.Kh2TextEditor/ViewModels/TextEditorViewModel.cs
@@ -28,7 +28,6 @@ namespace OpenKh.Tools.Kh2TextEditor.ViewModels
         private RenderingMessageContext textContext;
         private bool _showErrors;
 
-        public RelayCommand HandleReturn { get; }
         public RelayCommand HandleAddition { get; }
         public RelayCommand HandleRemoval { get; }
         public RelayCommand HandleComm { get; }
@@ -140,11 +139,6 @@ namespace OpenKh.Tools.Kh2TextEditor.ViewModels
             Drawing = new SpriteDrawingDirect3D();
             CurrentMessageEncoder = Encoders.InternationalSystem;
             _messages = new MessagesModel(this, this, new Msg.Entry[] { });
-
-            HandleReturn = new RelayCommand(x =>
-            {
-                Text += "{:newline}";                
-            });
 
             HandleRemoval = new RelayCommand(x =>
             {

--- a/OpenKh.Tools.Kh2TextEditor/Views/TextEditorView.xaml
+++ b/OpenKh.Tools.Kh2TextEditor/Views/TextEditorView.xaml
@@ -79,6 +79,7 @@
             <TextBox
                 x:Name="textInputField"
                 Grid.Row="0"
+                AcceptsReturn="True"
                 MaxLines="7" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"
                 Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}">
                 <TextBox.ContextMenu>
@@ -165,9 +166,6 @@
                         </MenuItem>
                     </ContextMenu>
                 </TextBox.ContextMenu>
-                <TextBox.InputBindings>
-                    <KeyBinding Key="Return" Command="{Binding HandleReturn}" />
-                </TextBox.InputBindings>
             </TextBox>
 
             <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">

--- a/docs/tool/GUI.Kh2TextEditor/index.md
+++ b/docs/tool/GUI.Kh2TextEditor/index.md
@@ -44,7 +44,6 @@ For now, let's list all the primary functions you will be likely to use, their t
 
 | Type | Human-Readable Format 	| Description
 |------|------------------------|------------------------
-| 02   | {:newline}             | Feeds a new line to the current selected text string. This argument becomes invisible upon reopening the string, but that is intended; it is still working.
 | 03   | {:reset}               | Resets all text afterwards to be argument-less.
 | 07   | {:color #RRGGBBAA}     | Forces all text after this argument to appear as the specified color in Hex. An AA value higher than 80 (default) will make your text appear bold, while values lower than 80 will make it appear less bold. The default color value for most text in the game is #F0F0F080.
 | 09   | {:icon icon-name}      | Displays the named icon within the text string. A list of all icons resides at the end of this document.
@@ -71,7 +70,7 @@ Let's test some more arguments for various texts in our sys.bar.
 | 482         | Items                                  | {:width 64}{:color 219542FF}Consumables
 | 483         | Drive                                  | {:width 50}{:color 218995FF}Transformations
 | 14133       | Kingdom Hearts                         | {:icon form}{:color D3D971FF}Classic Menu{:icon form}
-| 14135       | Keep the look of the original command menu. | {:scale 24}{:color D3D971FF}Use this if you prefer the classic{:newline}Command Menu.
+| 14135       | Keep the look of the original command menu. | {:scale 24}{:color D3D971FF}Use this if you prefer the classic Command Menu.
 
 <img src="./images/image03.png" width="640">
 


### PR DESCRIPTION
Brings the following changes:

* Say goodbye to `{:newstring}` as you now just need to press Enter to insert a new line.
* If opening a `sys.bar`, autodetects if European or Japanese encoding needs to be used.
* When opening a message file, autodetects `fontimage.bar` and `fontinfo.bar` rather than loading then manually.
* Updates documentation according to the latest changes.