### PR TITLE
Fix MapStudio crashing when it loads a model with no textures.

### DIFF
--- a/OpenKh.Tools.Kh2MapStudio/ObjEntryController.cs
+++ b/OpenKh.Tools.Kh2MapStudio/ObjEntryController.cs
@@ -71,14 +71,17 @@ namespace OpenKh.Tools.Kh2MapStudio
                     if (modelEntry != null)
                     {
                         var model = Mdlx.Read(modelEntry.Stream);
-                        var textures = ModelTexture.Read(mdlxEntries.First(x => x.Type == Bar.EntryType.ModelTexture).Stream);
+                        ModelTexture textures = null;
+
+                        try { textures = ModelTexture.Read(mdlxEntries.First(x => x.Type == Bar.EntryType.ModelTexture).Stream); }
+                        catch (System.InvalidOperationException) { }
 
                         var modelMotion = MeshLoader.FromKH2(model);
                         modelMotion.ApplyMotion(modelMotion.InitialPose);
                         meshGroup = new MeshGroup
                         {
                             MeshDescriptors = modelMotion.MeshDescriptors,
-                            Textures = textures.LoadTextures(_graphics).ToArray()
+                            Textures = textures == null ? new IKingdomTexture[0] : textures.LoadTextures(_graphics).ToArray()
                         };
                     }
                     else

--- a/OpenKh.Tools.Kh2MapStudio/ObjEntryController.cs
+++ b/OpenKh.Tools.Kh2MapStudio/ObjEntryController.cs
@@ -73,8 +73,9 @@ namespace OpenKh.Tools.Kh2MapStudio
                         var model = Mdlx.Read(modelEntry.Stream);
                         ModelTexture textures = null;
 
-                        try { textures = ModelTexture.Read(mdlxEntries.First(x => x.Type == Bar.EntryType.ModelTexture).Stream); }
-                        catch (System.InvalidOperationException) { }
+                        var textureEntry = mdlxEntries.FirstOrDefault(x => x.Type == Bar.EntryType.ModelTexture);
+                        if (textureEntry != null)
+                            textures = ModelTexture.Read(textureEntry.Stream);
 
                         var modelMotion = MeshLoader.FromKH2(model);
                         modelMotion.ApplyMotion(modelMotion.InitialPose);


### PR DESCRIPTION
A quick fix to #342. It's a fast fix, but it's an effective one.

Screenshot:
![image](https://user-images.githubusercontent.com/28973970/103489861-a3481280-4e28-11eb-8251-902bff3416b6.png)
