### PR TITLE
Standardise OpenKH Log across the entire codebase

### DIFF
--- a/OpenKh.Common/Log.cs
+++ b/OpenKh.Common/Log.cs
@@ -11,7 +11,7 @@ namespace OpenKh.Common
 {
     public static class Log
     {
-        public static readonly string AppName = NormalizeName(Assembly.GetExecutingAssembly().ManifestModule.ToString());
+        public static readonly string AppName = NormalizeName(Assembly.GetEntryAssembly().ManifestModule.ToString());
         private static readonly string LogFileName = $"{AppName}.log";
         private static readonly Task _taskLog;
         private static readonly Stopwatch _stopwatch = Stopwatch.StartNew();

--- a/OpenKh.Common/Log.cs
+++ b/OpenKh.Common/Log.cs
@@ -16,16 +16,16 @@ namespace OpenKh.Common
         private static readonly Task _taskLog;
         private static readonly Stopwatch _stopwatch = Stopwatch.StartNew();
         private static readonly StreamWriter _logWriter = new StreamWriter(LogFileName, false, Encoding.UTF8, 65536);
-        private static readonly Queue<(long ms, string tag, string fmt, string[] args)> _logQueue =
-            new Queue<(long, string, string, string[])>();
+        private static readonly Queue<(long ms, string tag, string fmt, object[] args)> _logQueue =
+            new Queue<(long, string, string, object[])>();
         private static readonly CancellationTokenSource _cancellationTokenSrc = new CancellationTokenSource();
 
         public delegate void LogDispatch(long ms, string tag, string message);
         public static event LogDispatch OnLogDispatch;
 
-        public static void Info(string fmt, params string[] args) => LogText("INF", fmt, args);
-        public static void Warn(string fmt, params string[] args) => LogText("WRN", fmt, args);
-        public static void Err(string fmt, params string[] args) => LogText("ERR", fmt, args);
+        public static void Info(string fmt, params object[] args) => LogText("INF", fmt, args);
+        public static void Warn(string fmt, params object[] args) => LogText("WRN", fmt, args);
+        public static void Err(string fmt, params object[] args) => LogText("ERR", fmt, args);
 
         static Log()
         {
@@ -66,7 +66,7 @@ namespace OpenKh.Common
             throw new TimeoutException("Could not flush logs within the time limit");
         }
 
-        private static void LogText(string tag, string fmt, string[] args)
+        private static void LogText(string tag, string fmt, object[] args)
         {
             var ms = _stopwatch.ElapsedMilliseconds;
             lock (_logQueue)

--- a/OpenKh.Common/Log.cs
+++ b/OpenKh.Common/Log.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace OpenKh.Game.Debugging
+namespace OpenKh.Common
 {
     public static class Log
     {

--- a/OpenKh.Game/Config.cs
+++ b/OpenKh.Game/Config.cs
@@ -1,4 +1,4 @@
-using OpenKh.Game.Debugging;
+using OpenKh.Common;
 using System;
 using System.IO;
 using System.Threading;

--- a/OpenKh.Game/Config.cs
+++ b/OpenKh.Game/Config.cs
@@ -70,12 +70,12 @@ namespace OpenKh.Game
         {
             if (!File.Exists(ConfigFilePath))
             {
-                Log.Info($"Configuration file not found at {ActualConfigFilePath}. Creating default configuraiton.");
+                Log.Info("Configuration file not found at {0}. Creating default configuraiton.", ActualConfigFilePath);
                 Save();
             }
             else
             {
-                Log.Info($"Load configuration file from {ActualConfigFilePath}");
+                Log.Info("Load configuration file from {0}", ActualConfigFilePath);
                 try
                 {
                     _config = ActualConfig.ReadFromFile(ActualConfigFilePath) ?? ActualConfig.Default();
@@ -131,7 +131,7 @@ namespace OpenKh.Game
 
         public static void Save()
         {
-            Log.Info($"Save configuration file to {ActualConfigFilePath}");
+            Log.Info("Save configuration file to {0}, ActualConfigFilePath");
             InternalSave();
         }
 

--- a/OpenKh.Game/DataContent/IdxDataContent.cs
+++ b/OpenKh.Game/DataContent/IdxDataContent.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using OpenKh.Game.Debugging;
+using OpenKh.Common;
 using OpenKh.Game.Infrastructure;
 using OpenKh.Kh2;
 

--- a/OpenKh.Game/DataContent/IdxDataContent.cs
+++ b/OpenKh.Game/DataContent/IdxDataContent.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using OpenKh.Common;
 using OpenKh.Game.Infrastructure;
 using OpenKh.Kh2;
@@ -18,7 +18,7 @@ namespace OpenKh.Game.DataContent
 
         public Stream FileOpen(string path)
         {
-            Log.Info($"Load IDX file {path}");
+            Log.Info("Load IDX file {0}", path);
             return _img.TryFileOpen(path, out var stream) ? stream : null;
         }
     }

--- a/OpenKh.Game/DataContent/ModDataContent.cs
+++ b/OpenKh.Game/DataContent/ModDataContent.cs
@@ -1,4 +1,4 @@
-﻿using OpenKh.Common;
+using OpenKh.Common;
 using OpenKh.Game.Infrastructure;
 using System.IO;
 
@@ -13,7 +13,7 @@ namespace OpenKh.Game.DataContent
             var fileName = GetPath(path);
             if (File.Exists(fileName))
             {
-                Log.Info($"Load mod {path}");
+                Log.Info("Load mod {0}", path);
                 return File.OpenRead(fileName);
             }
 

--- a/OpenKh.Game/DataContent/ModDataContent.cs
+++ b/OpenKh.Game/DataContent/ModDataContent.cs
@@ -1,4 +1,4 @@
-﻿using OpenKh.Game.Debugging;
+﻿using OpenKh.Common;
 using OpenKh.Game.Infrastructure;
 using System.IO;
 

--- a/OpenKh.Game/DataContent/StandardDataContent.cs
+++ b/OpenKh.Game/DataContent/StandardDataContent.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using OpenKh.Game.Debugging;
+using OpenKh.Common;
 using OpenKh.Game.Infrastructure;
 
 namespace OpenKh.Game.DataContent

--- a/OpenKh.Game/DataContent/StandardDataContent.cs
+++ b/OpenKh.Game/DataContent/StandardDataContent.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using OpenKh.Common;
 using OpenKh.Game.Infrastructure;
 
@@ -17,7 +17,7 @@ namespace OpenKh.Game.DataContent
 
         public Stream FileOpen(string path)
         {
-            Log.Info($"Load file {path}");
+            Log.Info("Load file {0}", path);
             var fileName = GetPath(path);
             if (File.Exists(fileName))
                 return File.OpenRead(fileName);

--- a/OpenKh.Game/Entities/ObjectEntity.cs
+++ b/OpenKh.Game/Entities/ObjectEntity.cs
@@ -1,7 +1,7 @@
 using Microsoft.Xna.Framework.Graphics;
 using OpenKh.Engine.MonoGame;
 using OpenKh.Engine.Motion;
-using OpenKh.Game.Debugging;
+using OpenKh.Common;
 using OpenKh.Game.Infrastructure;
 using OpenKh.Common;
 using OpenKh.Bbs;

--- a/OpenKh.Game/Entities/ObjectEntity.cs
+++ b/OpenKh.Game/Entities/ObjectEntity.cs
@@ -62,7 +62,7 @@ namespace OpenKh.Game.Entities
             var objEntry = Kernel.ObjEntries.FirstOrDefault(x => x.ObjectId == ObjectId);
             if (objEntry == null)
             {
-                Log.Warn($"Object ID {ObjectId} not found.");
+                Log.Warn("Object ID {0} not found.", ObjectId);
                 return;
             }
 
@@ -89,7 +89,7 @@ namespace OpenKh.Game.Entities
                 else
                 {
                     Motion = new Kh2MotionEngine();
-                    Log.Warn($"MSET {objEntry.AnimationName} does not exist");
+                    Log.Warn("MSET {0} does not exist", objEntry.AnimationName);
                 }
             }
             catch (System.NotImplementedException)

--- a/OpenKh.Game/Infrastructure/Kernel.cs
+++ b/OpenKh.Game/Infrastructure/Kernel.cs
@@ -3,7 +3,7 @@ using OpenKh.Common.Archives;
 using OpenKh.Engine;
 using OpenKh.Engine.Extensions;
 using OpenKh.Engine.Renders;
-using OpenKh.Game.Debugging;
+using OpenKh.Common;
 using OpenKh.Kh2;
 using OpenKh.Kh2.Battle;
 using OpenKh.Kh2.Contextes;

--- a/OpenKh.Game/Infrastructure/Kernel.cs
+++ b/OpenKh.Game/Infrastructure/Kernel.cs
@@ -109,13 +109,13 @@ namespace OpenKh.Game.Infrastructure
             FontContext = new FontContext();
             MessageProvider = new Kh2MessageProvider();
             _regionId = DetectRegion(dataContent);
-            Log.Info($"Region={Region} Language={Language}");
+            Log.Info("Region={0} Language={1}", Region, Language);
 
             IsReMix = IsReMixFileExists(dataContent, Region);
-            Log.Info($"ReMIX={IsReMix}");
+            Log.Info("ReMIX={0}", IsReMix);
 
             IsFinalMix = IsReMix || RegionId == Constants.RegionFinalMix;
-            Log.Info($"Final Mix={IsFinalMix}");
+            Log.Info("Final Mix={0}", IsFinalMix);
 
             // Load files in the same order as KH2 does
             ObjEntries = LoadFile("00objentry.bin", stream => Objentry.Read(stream));
@@ -170,11 +170,11 @@ namespace OpenKh.Game.Infrastructure
         public void LoadSaveData(string fileName)
         {
             var savePath = Path.Combine(Config.SavePath, fileName);
-            Log.Info($"Attempting to load save {savePath}...");
+            Log.Info("Attempting to load save {0}...", savePath);
             if (File.Exists(savePath))
                 File.OpenRead(savePath).Using(LoadSaveData);
             else
-                Log.Warn($"Save {savePath} not found");
+                Log.Warn("Save {0} not found", savePath);
         }
 
         public bool LoadSaveData(Stream stream)
@@ -243,7 +243,7 @@ namespace OpenKh.Game.Infrastructure
                 var testFileName = $"menu/{Constants.Regions[i]}/title.2ld";
                 if (dataContent.FileExists(testFileName))
                 {
-                    Log.Info($"Region ID candidate: {i}");
+                    Log.Info("Region ID candidate: {0}", i);
                     return i;
                 }
             }

--- a/OpenKh.Game/Infrastructure/Kh2Field.cs
+++ b/OpenKh.Game/Infrastructure/Kh2Field.cs
@@ -5,7 +5,7 @@ using OpenKh.Engine;
 using OpenKh.Engine.Extensions;
 using OpenKh.Engine.MonoGame;
 using OpenKh.Engine.Renders;
-using OpenKh.Game.Debugging;
+using OpenKh.Common;
 using OpenKh.Game.Entities;
 using OpenKh.Game.Events;
 using OpenKh.Kh2;

--- a/OpenKh.Game/Infrastructure/Kh2Field.cs
+++ b/OpenKh.Game/Infrastructure/Kh2Field.cs
@@ -121,7 +121,7 @@ namespace OpenKh.Game.Infrastructure
                 .Select(x => x.Name)
                 .ToList();
 
-            Log.Info($"Loading spawn {_kernel.SpawnName}");
+            Log.Info("Loading spawn {0}", _kernel.SpawnName);
             RunSpawnScript(_binarcArd, "map", _spawnScriptMap >= 0 ? _spawnScriptMap : _kernel.SpawnMap);
             RunSpawnScript(_binarcArd, "btl", _spawnScriptBtl >= 0 ? _spawnScriptBtl : _kernel.SpawnBtl);
             RunSpawnScript(_binarcArd, "evt", _spawnScriptEvt >= 0 ? _spawnScriptEvt : _kernel.SpawnEvt);
@@ -392,7 +392,7 @@ namespace OpenKh.Game.Infrastructure
                 switch (function)
                 {
                     case AreaDataScript.Spawn spawn:
-                        Log.Info($"Loading spawn {spawn.SpawnSet}");
+                        Log.Info("Loading spawn {0}", spawn.SpawnSet);
                         var spawnPoints = barEntries.ForEntry(spawn.SpawnSet, Bar.EntryType.AreaDataSpawn, SpawnPoint.Read);
                         if (spawnPoints != null)
                         {
@@ -406,7 +406,7 @@ namespace OpenKh.Game.Infrastructure
                             }
                         }
                         else
-                            Log.Warn($"Unable to find spawn \"{spawn}\".");
+                            Log.Warn("Unable to find spawn \"{0}\".", spawn);
                         break;
                 }
             }

--- a/OpenKh.Game/Menu/MenuStatus.cs
+++ b/OpenKh.Game/Menu/MenuStatus.cs
@@ -284,7 +284,7 @@ namespace OpenKh.Game.Menu
                 var saveData = MenuManager.GameContext.Kernel.SaveData;
                 if (characterIndex < 0 || characterIndex >= (saveData.Characters?.Length ?? 0))
                 {
-                    Log.Err($"Stats for character '{characterIndex}' is out of range");
+                    Log.Err("Stats for character '{0}' is out of range", characterIndex);
                     yield break;
                 }
 
@@ -292,7 +292,7 @@ namespace OpenKh.Game.Menu
                 var character = saveData.Characters[characterIndex];
                 if (character == null)
                 {
-                    Log.Err($"Stats for character '{characterIndex}' is null");
+                    Log.Err("Stats for character '{0}' is null", characterIndex);
                     yield break;
                 }
 
@@ -324,14 +324,14 @@ namespace OpenKh.Game.Menu
                 var saveData = MenuManager.GameContext.Kernel.SaveData;
                 if (characterIndex < 0 || characterIndex >= (saveData.Characters?.Length ?? 0))
                 {
-                    Log.Err($"Stats for character '{characterIndex}' is out of range");
+                    Log.Err("Stats for character '{0}' is out of range", characterIndex);
                     yield break;
                 }
 
                 var character = saveData.Characters[characterIndex];
                 if (character == null)
                 {
-                    Log.Err($"Stats for character '{characterIndex}' is null");
+                    Log.Err("Stats for character '{0}' is null", characterIndex);
                     yield break;
                 }
 
@@ -355,13 +355,13 @@ namespace OpenKh.Game.Menu
                 var saveData = MenuManager.GameContext.Kernel.SaveData;
                 if (driveFormIndex < 0 || driveFormIndex >= (saveData.DriveForms?.Length ?? 0))
                 {
-                    Log.Err($"Stats for drive form '{driveFormIndex}' is out of range");
+                    Log.Err("Stats for drive form '{0}' is out of range", driveFormIndex);
                     yield break;
                 }
                 var driveForm = saveData.DriveForms[driveFormIndex];
                 if (driveForm == null)
                 {
-                    Log.Err($"Stats for drive form '{driveFormIndex}' is null");
+                    Log.Err("Stats for drive form '{0}' is null", driveFormIndex);
                     yield break;
                 }
 

--- a/OpenKh.Game/Menu/MenuStatus.cs
+++ b/OpenKh.Game/Menu/MenuStatus.cs
@@ -1,5 +1,5 @@
 using OpenKh.Engine.Renderers;
-using OpenKh.Game.Debugging;
+using OpenKh.Common;
 using OpenKh.Game.Infrastructure;
 using System.Collections.Generic;
 using System.Linq;

--- a/OpenKh.Game/OpenKhGame.cs
+++ b/OpenKh.Game/OpenKhGame.cs
@@ -40,7 +40,7 @@ namespace OpenKh.Game
         {
             set
             {
-                Log.Info($"State={value}");
+                Log.Info("State={0}", value);
                 switch (value)
                 {
                     case 0:
@@ -60,7 +60,7 @@ namespace OpenKh.Game
                         state = myState;
                         break;
                     default:
-                        Log.Err($"Invalid state {value}");
+                        Log.Err("Invalid state {0}", value);
                         return;
                 }
 
@@ -102,7 +102,7 @@ namespace OpenKh.Game
             var resolutionWidth = GetResolutionWidth();
             var resolutionHeight = GetResolutionHeight();
 
-            Log.Info($"Internal game resolution set to {resolutionWidth}x{resolutionHeight}");
+            Log.Info("Internal game resolution set to {0}x{1}", resolutionWidth, resolutionHeight);
 
             graphics = new GraphicsDeviceManager(this)
             {
@@ -229,13 +229,13 @@ namespace OpenKh.Game
 
         private static IDataContent CreateDataContent(string basePath, string idxFileName, string imgFileName)
         {
-            Log.Info($"Base directory is {basePath}");
+            Log.Info("Base directory is {0}", basePath);
 
             var idxFullPath = Path.Combine(basePath, idxFileName);
             var imgFullPath = Path.Combine(basePath, imgFileName);
             if (File.Exists(idxFullPath) && File.Exists(imgFullPath))
             {
-                Log.Info($"{idxFullPath} and {imgFullPath} has been found");
+                Log.Info("{0} and {1} has been found", idxFullPath, imgFullPath);
 
                 var imgStream = File.OpenRead(imgFullPath);
                 var idxDataContent = File.OpenRead(idxFullPath)
@@ -248,7 +248,7 @@ namespace OpenKh.Game
             }
             else
             {
-                Log.Info($"No {idxFullPath} or {imgFullPath}, loading extracted files");
+                Log.Info("No {0} or {1}, loading extracted files", idxFullPath, imgFullPath);
                 return new StandardDataContent(basePath);
             }
         }

--- a/OpenKh.Game/Program.cs
+++ b/OpenKh.Game/Program.cs
@@ -28,7 +28,7 @@ namespace OpenKh.Game
         static void Main(string[] args)
         {
             Log.Info("Boot");
-            Log.Info($"Version {ProductVersion}");
+            Log.Info("Version {0}", ProductVersion);
             void run()
             {
                 Config.Open();
@@ -126,7 +126,7 @@ namespace OpenKh.Game
 
         private static void Catch(Exception ex)
         {
-            Log.Err($"{ex.GetType().Name}: {ex.Message}:\n{ex.StackTrace}");
+            Log.Err("{0}: {1}:\n{2}", ex.GetType().Name, ex.Message, ex.StackTrace);
             if (ex.InnerException != null)
                 Catch(ex.InnerException);
         }

--- a/OpenKh.Game/Program.cs
+++ b/OpenKh.Game/Program.cs
@@ -1,6 +1,6 @@
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Win32.SafeHandles;
-using OpenKh.Game.Debugging;
+using OpenKh.Common;
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.IO;

--- a/OpenKh.Game/States/MapState.cs
+++ b/OpenKh.Game/States/MapState.cs
@@ -334,7 +334,7 @@ namespace OpenKh.Game.States
 
         private void LoadMap(int worldIndex, int placeIndex)
         {
-            Log.Info($"Map={worldIndex},{placeIndex}");
+            Log.Info("Map={0},{1}", worldIndex, placeIndex);
 
             var fileName = Kernel.GetMapFileName(worldIndex, placeIndex);
             var entries = _dataContent.FileOpen(fileName).Using(Bar.Read);

--- a/OpenKh.Game/States/MenuState.cs
+++ b/OpenKh.Game/States/MenuState.cs
@@ -7,6 +7,7 @@ using OpenKh.Game.Menu;
 using OpenKh.Kh2;
 using System.Collections.Generic;
 using System.Linq;
+using OpenKh.Game.Debugging;
 
 namespace OpenKh.Game.States
 {

--- a/OpenKh.Game/States/Title/TitleState.cs
+++ b/OpenKh.Game/States/Title/TitleState.cs
@@ -2,7 +2,7 @@ using OpenKh.Engine.Extensions;
 using OpenKh.Engine.MonoGame;
 using OpenKh.Engine.Renderers;
 using OpenKh.Engine.Renders;
-using OpenKh.Game.Debugging;
+using OpenKh.Common;
 using OpenKh.Game.Infrastructure;
 using OpenKh.Kh2;
 using System;

--- a/OpenKh.Game/States/Title/TitleState.cs
+++ b/OpenKh.Game/States/Title/TitleState.cs
@@ -74,7 +74,7 @@ namespace OpenKh.Game.States.Title
                         _subMenu = new NewGameMenu(_animatedSequenceFactory, this);
                         break;
                     default:
-                        Log.Warn($"Submenu {value.ToString()} not implemented.");
+                        Log.Warn("Submenu {0} not implemented.", value);
                         break;
                 }
 
@@ -153,7 +153,7 @@ namespace OpenKh.Game.States.Title
                 _titleLayout.SequenceItems[0],
                 images.First());
 
-            Log.Info($"Theater={_titleLayoutDesc.HasTheater}");
+            Log.Info("Theater={0}", _titleLayoutDesc.HasTheater);
             if (_titleLayoutDesc.HasTheater)
             {
                 (_theaterLayout, images) = GetLayoutResources("even", "even");
@@ -307,7 +307,7 @@ namespace OpenKh.Game.States.Title
 
         private void SetOption(int option)
         {
-            Log.Info($"TitleOption={option} prev={_optionSelected}");
+            Log.Info("TitleOption={0} prev={1}", option, _optionSelected);
             _optionSelected = option;
 
             switch (_optionSelected)


### PR DESCRIPTION
Move `Log` from `OpenKh.Game` to `OpenKh.Common`, so every project can use it by just doing `Log.Error("MyError")` without any set-up. The log takes the name of the executable file, so if you log from the app `OpenKh.Tools.MapStudio` the log will be called `OpenKh.Tools.MapStudio.log`. You do not need to deal with any configuration, _just log™_

Another feature is that you can hook incoming log messages. Just do a `Log.OnLogDispatch += MyLogHandler` to get them. That way you can for example display log messages into an application.