### PR TITLE
Remove monogame dependency and slightly improve performance

### DIFF
--- a/OpenKh.Engine.MonoGame/Camera.cs
+++ b/OpenKh.Engine.MonoGame/Camera.cs
@@ -133,7 +133,7 @@ namespace OpenKh.Engine.MonoGame
             }
         }
 
-        public System.Numerics.Matrix4x4 Projection
+        public Matrix4x4 Projection
         {
             get
             {
@@ -143,7 +143,7 @@ namespace OpenKh.Engine.MonoGame
             }
         }
 
-        public System.Numerics.Matrix4x4 World
+        public Matrix4x4 World
         {
             get
             {
@@ -170,7 +170,7 @@ namespace OpenKh.Engine.MonoGame
 
         private void CalculateProjection()
         {
-            _projection = System.Numerics.Matrix4x4.CreatePerspectiveFieldOfView(
+            _projection = Matrix4x4.CreatePerspectiveFieldOfView(
                 _fov, _aspectRatio, _nearClipPlane, _farClipPlane);
 
             ValidateProjection();
@@ -178,10 +178,10 @@ namespace OpenKh.Engine.MonoGame
 
         private void CalculateWorld()
         {
-            _world = System.Numerics.Matrix4x4.CreateLookAt(
-                new System.Numerics.Vector3(CameraPosition.X, CameraPosition.Y, CameraPosition.Z),
-                new System.Numerics.Vector3(CameraLookAt.X, CameraLookAt.Y, CameraLookAt.Z),
-                new System.Numerics.Vector3(CameraUp.X, CameraUp.Y, CameraUp.Z));
+            _world = Matrix4x4.CreateLookAt(
+                new Vector3(CameraPosition.X, CameraPosition.Y, CameraPosition.Z),
+                new Vector3(CameraLookAt.X, CameraLookAt.Y, CameraLookAt.Z),
+                new Vector3(CameraUp.X, CameraUp.Y, CameraUp.Z));
 
             ValidateWorld();
         }

--- a/OpenKh.Engine.MonoGame/Camera.cs
+++ b/OpenKh.Engine.MonoGame/Camera.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using System.Numerics;
 
 namespace OpenKh.Engine.MonoGame
 {
@@ -14,8 +14,8 @@ namespace OpenKh.Engine.MonoGame
         private Vector3 _cameraLookAtY;
         private Vector3 _cameraLookAtZ;
         private Vector3 _cameraUp;
-        private Matrix _projection;
-        private Matrix _world;
+        private Matrix4x4 _projection;
+        private Matrix4x4 _world;
         private bool _isProjectionInvalidated;
         private bool _isWorldInvalidated;
         private Vector3 _cameraYpr;
@@ -126,14 +126,14 @@ namespace OpenKh.Engine.MonoGame
             set
             {
                 _cameraYpr = value;
-                var matrix = Matrix.CreateFromYawPitchRoll(value.X / 180.0f * 3.14159f, value.Y / 180.0f * 3.14159f, value.Z / 180.0f * 3.14159f);
+                var matrix = Matrix4x4.CreateFromYawPitchRoll(value.X / 180.0f * 3.14159f, value.Y / 180.0f * 3.14159f, value.Z / 180.0f * 3.14159f);
                 CameraLookAtX = Vector3.Transform(new Vector3(1, 0, 0), matrix);
                 CameraLookAtY = Vector3.Transform(new Vector3(0, 0, 1), matrix);
                 CameraLookAtZ = Vector3.Transform(new Vector3(0, 1, 0), matrix);
             }
         }
 
-        public Matrix Projection
+        public System.Numerics.Matrix4x4 Projection
         {
             get
             {
@@ -143,7 +143,7 @@ namespace OpenKh.Engine.MonoGame
             }
         }
 
-        public Matrix World
+        public System.Numerics.Matrix4x4 World
         {
             get
             {
@@ -170,7 +170,7 @@ namespace OpenKh.Engine.MonoGame
 
         private void CalculateProjection()
         {
-            _projection = Matrix.CreatePerspectiveFieldOfView(
+            _projection = System.Numerics.Matrix4x4.CreatePerspectiveFieldOfView(
                 _fov, _aspectRatio, _nearClipPlane, _farClipPlane);
 
             ValidateProjection();
@@ -178,7 +178,10 @@ namespace OpenKh.Engine.MonoGame
 
         private void CalculateWorld()
         {
-            _world = Matrix.CreateLookAt(CameraPosition, CameraLookAt, CameraUp);
+            _world = System.Numerics.Matrix4x4.CreateLookAt(
+                new System.Numerics.Vector3(CameraPosition.X, CameraPosition.Y, CameraPosition.Z),
+                new System.Numerics.Vector3(CameraLookAt.X, CameraLookAt.Y, CameraLookAt.Z),
+                new System.Numerics.Vector3(CameraUp.X, CameraUp.Y, CameraUp.Z));
 
             ValidateWorld();
         }

--- a/OpenKh.Engine.MonoGame/Extensions.cs
+++ b/OpenKh.Engine.MonoGame/Extensions.cs
@@ -77,12 +77,5 @@ namespace OpenKh.Engine.MonoGame
                 pass.Apply();
             }
         }
-
-        public static Microsoft.Xna.Framework.Matrix ToXna(this System.Numerics.Matrix4x4 m) =>
-            new Microsoft.Xna.Framework.Matrix(
-                m.M11, m.M12, m.M13, m.M14,
-                m.M21, m.M22, m.M23, m.M24,
-                m.M31, m.M32, m.M33, m.M34,
-                m.M41, m.M42, m.M43, m.M44);
     }
 }

--- a/OpenKh.Engine.MonoGame/Extensions.cs
+++ b/OpenKh.Engine.MonoGame/Extensions.cs
@@ -25,38 +25,38 @@ namespace OpenKh.Engine.MonoGame
                 switch (texture.AddressU)
                 {
                     case ModelTexture.TextureWrapMode.Clamp:
-                        shader.TextureRegionU = KingdomShader.DefaultTextureRegion;
+                        shader.SetTextureRegionUDefault();
                         shader.TextureWrapModeU = TextureWrapMode.Clamp;
                         break;
                     case ModelTexture.TextureWrapMode.Repeat:
-                        shader.TextureRegionU = KingdomShader.DefaultTextureRegion;
+                        shader.SetTextureRegionUDefault();
                         shader.TextureWrapModeU = TextureWrapMode.Repeat;
                         break;
                     case ModelTexture.TextureWrapMode.RegionClamp:
-                        shader.TextureRegionU = texture.RegionU;
+                        shader.SetTextureRegionU(texture.RegionU);
                         shader.TextureWrapModeU = TextureWrapMode.Clamp;
                         break;
                     case ModelTexture.TextureWrapMode.RegionRepeat:
-                        shader.TextureRegionU = texture.RegionU;
+                        shader.SetTextureRegionU(texture.RegionU);
                         shader.TextureWrapModeU = TextureWrapMode.Repeat;
                         break;
                 }
                 switch (texture.AddressV)
                 {
                     case ModelTexture.TextureWrapMode.Clamp:
-                        shader.TextureRegionV = KingdomShader.DefaultTextureRegion;
+                        shader.SetTextureRegionVDefault();
                         shader.TextureWrapModeV = TextureWrapMode.Clamp;
                         break;
                     case ModelTexture.TextureWrapMode.Repeat:
-                        shader.TextureRegionV = KingdomShader.DefaultTextureRegion;
+                        shader.SetTextureRegionVDefault();
                         shader.TextureWrapModeV = TextureWrapMode.Repeat;
                         break;
                     case ModelTexture.TextureWrapMode.RegionClamp:
-                        shader.TextureRegionV = texture.RegionV;
+                        shader.SetTextureRegionV(texture.RegionV);
                         shader.TextureWrapModeV = TextureWrapMode.Clamp;
                         break;
                     case ModelTexture.TextureWrapMode.RegionRepeat:
-                        shader.TextureRegionV = texture.RegionV;
+                        shader.SetTextureRegionV(texture.RegionV);
                         shader.TextureWrapModeV = TextureWrapMode.Repeat;
                         break;
                 }
@@ -70,8 +70,8 @@ namespace OpenKh.Engine.MonoGame
             if (shader.Texture0 != texture)
             {
                 shader.Texture0 = texture;
-                shader.TextureRegionU = KingdomShader.DefaultTextureRegion;
-                shader.TextureRegionV = KingdomShader.DefaultTextureRegion;
+                shader.SetTextureRegionVDefault();
+                shader.SetTextureRegionUDefault();
                 shader.TextureWrapModeU = TextureWrapMode.Clamp;
                 shader.TextureWrapModeV = TextureWrapMode.Clamp;
                 pass.Apply();

--- a/OpenKh.Engine.MonoGame/KingdomShader.cs
+++ b/OpenKh.Engine.MonoGame/KingdomShader.cs
@@ -1,14 +1,17 @@
-﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using OpenKh.Engine.Renders;
 using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using xna = Microsoft.Xna.Framework;
 
 namespace OpenKh.Engine.MonoGame
 {
     public class KingdomShader : IDisposable
     {
-        public static readonly Vector2 DefaultTextureRegion = new Vector2(0, 1);
+        private static Matrix4x4 MatrixIdentity = Matrix4x4.Identity;
+        public static Vector2 DefaultTextureRegion = new Vector2(0, 1);
 
         private readonly EffectParameter _modelViewParameter;
         private readonly EffectParameter _worldViewParameter;
@@ -33,34 +36,43 @@ namespace OpenKh.Engine.MonoGame
             _parameterTexture0 = Effect.Parameters["Texture0"];
             _parameterUseAlphaMask = Effect.Parameters["UseAlphaMask"];
 
-            ModelView = Matrix.Identity;
-            WorldView = Matrix.Identity;
-            ProjectionView = Matrix.Identity;
-            TextureRegionU = DefaultTextureRegion;
-            TextureRegionV = DefaultTextureRegion;
+            SetModelViewIdentity();
+            SetWorldViewIdentity();
+            SetProjectionViewIdentity();
+            SetTextureRegionUDefault();
+            SetTextureRegionVDefault();
             TextureWrapModeU = TextureWrapMode.Clamp;
             TextureWrapModeV = TextureWrapMode.Clamp;
         }
 
         public Effect Effect { get; }
 
-        public Matrix ModelView
-        {
-            get => _modelViewParameter.GetValueMatrix();
-            set => _modelViewParameter.SetValue(value);
-        }
+        public void SetModelViewIdentity() =>
+            _modelViewParameter.SetValue(Unsafe.As<Matrix4x4, xna.Matrix>(ref MatrixIdentity));
 
-        public Matrix WorldView
-        {
-            get => _worldViewParameter.GetValueMatrix();
-            set => _worldViewParameter.SetValue(value);
-        }
+        public void SetModelView(Matrix4x4 matrix) =>
+            _modelViewParameter.SetValue(Unsafe.As<Matrix4x4, xna.Matrix>(ref matrix));
 
-        public Matrix ProjectionView
-        {
-            get => _projectionViewParameter.GetValueMatrix();
-            set => _projectionViewParameter.SetValue(value);
-        }
+        public void SetModelView(ref Matrix4x4 matrix) =>
+            _modelViewParameter.SetValue(Unsafe.As<Matrix4x4, xna.Matrix>(ref matrix));
+
+        public void SetWorldViewIdentity() =>
+            _worldViewParameter.SetValue(Unsafe.As<Matrix4x4, xna.Matrix>(ref MatrixIdentity));
+
+        public void SetWorldView(Matrix4x4 matrix) =>
+            _worldViewParameter.SetValue(Unsafe.As<Matrix4x4, xna.Matrix>(ref matrix));
+
+        public void SetWorldView(ref Matrix4x4 matrix) =>
+            _worldViewParameter.SetValue(Unsafe.As<Matrix4x4, xna.Matrix>(ref matrix));
+
+        public void SetProjectionViewIdentity() =>
+            _projectionViewParameter.SetValue(Unsafe.As<Matrix4x4, xna.Matrix>(ref MatrixIdentity));
+
+        public void SetProjectionView(Matrix4x4 matrix) =>
+            _projectionViewParameter.SetValue(Unsafe.As<Matrix4x4, xna.Matrix>(ref matrix));
+
+        public void SetProjectionView(ref Matrix4x4 matrix) =>
+            _projectionViewParameter.SetValue(Unsafe.As<Matrix4x4, xna.Matrix>(ref matrix));
 
         public Texture2D Texture0
         {
@@ -68,16 +80,19 @@ namespace OpenKh.Engine.MonoGame
             set => _parameterTexture0.SetValue(value);
         }
 
-        public Vector2 TextureRegionU
-        {
-            get => _parameterTextureRegionU.GetValueVector2();
-            set => _parameterTextureRegionU.SetValue(value);
-        }
-        public Vector2 TextureRegionV
-        {
-            get => _parameterTextureRegionV.GetValueVector2();
-            set => _parameterTextureRegionV.SetValue(value);
-        }
+        public void SetTextureRegionU(Vector2 vector) =>
+            _parameterTextureRegionU.SetValue(Unsafe.As<Vector2, xna.Vector2>(ref vector));
+        public void SetTextureRegionU(ref Vector2 vector) =>
+            _parameterTextureRegionU.SetValue(Unsafe.As<Vector2, xna.Vector2>(ref vector));
+        public void SetTextureRegionUDefault() =>
+            _parameterTextureRegionU.SetValue(Unsafe.As<Vector2, xna.Vector2>(ref DefaultTextureRegion));
+
+        public void SetTextureRegionV(Vector2 vector) =>
+            _parameterTextureRegionV.SetValue(Unsafe.As<Vector2, xna.Vector2>(ref vector));
+        public void SetTextureRegionV(ref Vector2 vector) =>
+            _parameterTextureRegionV.SetValue(Unsafe.As<Vector2, xna.Vector2>(ref vector));
+        public void SetTextureRegionVDefault() =>
+            _parameterTextureRegionV.SetValue(Unsafe.As<Vector2, xna.Vector2>(ref DefaultTextureRegion));
 
         public TextureWrapMode TextureWrapModeU
         {

--- a/OpenKh.Engine.MonoGame/KingdomTexture.cs
+++ b/OpenKh.Engine.MonoGame/KingdomTexture.cs
@@ -1,12 +1,10 @@
-using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using OpenKh.Common;
 using OpenKh.Kh2;
 using OpenKh.Imaging;
 using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Linq;
+using System.Numerics;
 
 namespace OpenKh.Engine.MonoGame
 {

--- a/OpenKh.Engine.MonoGame/MonoSpriteDrawing.cs
+++ b/OpenKh.Engine.MonoGame/MonoSpriteDrawing.cs
@@ -1,9 +1,10 @@
-using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using OpenKh.Engine.Extensions;
 using OpenKh.Engine.Renders;
 using OpenKh.Imaging;
 using System.Linq;
+using System.Numerics;
+using xna = Microsoft.Xna.Framework;
 
 namespace OpenKh.Engine.MonoGame
 {
@@ -67,7 +68,7 @@ namespace OpenKh.Engine.MonoGame
             AlphaDestinationBlend = Blend.InverseSourceAlpha,
             ColorBlendFunction = BlendFunction.Add,
             AlphaBlendFunction = BlendFunction.Add,
-            BlendFactor = Color.White,
+            BlendFactor = xna.Color.White,
             MultiSampleMask = int.MaxValue,
             IndependentBlendEnable = false
         };
@@ -79,7 +80,7 @@ namespace OpenKh.Engine.MonoGame
             AlphaDestinationBlend = Blend.One,
             ColorBlendFunction = BlendFunction.Add,
             AlphaBlendFunction = BlendFunction.Add,
-            BlendFactor = Color.White,
+            BlendFactor = xna.Color.White,
             MultiSampleMask = int.MaxValue,
             IndependentBlendEnable = false
         };
@@ -91,7 +92,7 @@ namespace OpenKh.Engine.MonoGame
             AlphaDestinationBlend = Blend.InverseSourceAlpha,
             ColorBlendFunction = BlendFunction.ReverseSubtract,
             AlphaBlendFunction = BlendFunction.ReverseSubtract,
-            BlendFactor = Color.White,
+            BlendFactor = xna.Color.White,
             MultiSampleMask = int.MaxValue,
             IndependentBlendEnable = false,
         };
@@ -110,7 +111,7 @@ namespace OpenKh.Engine.MonoGame
 
         private Texture2D _lastTextureUsed;
         private BlendState _lastBlendState;
-        private Matrix _projectionView;
+        private Matrix4x4 _projectionView;
 
         private Vector2 _textureRegionU;
         private Vector2 _textureRegionV;
@@ -189,11 +190,11 @@ namespace OpenKh.Engine.MonoGame
 
         public void SetViewport(float left, float right, float top, float bottom)
         {
-            _projectionView = Matrix.CreateOrthographicOffCenter(left, right, bottom, top, -1000.0f, +1000.0f);
+            _projectionView = Matrix4x4.CreateOrthographicOffCenter(left, right, bottom, top, -1000.0f, +1000.0f);
         }
 
         public void Clear(ColorF color) =>
-            _graphicsDevice.Clear(new Color(color.R, color.G, color.B, color.A));
+            _graphicsDevice.Clear(new xna.Color(color.R, color.G, color.B, color.A));
 
         public void AppendSprite(SpriteDrawingContext context)
         {
@@ -272,11 +273,11 @@ namespace OpenKh.Engine.MonoGame
             _shader.Pass(pass =>
             {
                 _shader.Texture0 = _lastTextureUsed;
-                _shader.ProjectionView = _projectionView;
-                _shader.WorldView = Matrix.Identity;
-                _shader.ModelView = Matrix.Identity;
-                _shader.TextureRegionU = _textureRegionU;
-                _shader.TextureRegionV = _textureRegionV;
+                _shader.SetProjectionView(ref _projectionView);
+                _shader.SetWorldViewIdentity();
+                _shader.SetModelViewIdentity();
+                _shader.SetTextureRegionU(ref _textureRegionU);
+                _shader.SetTextureRegionV(ref _textureRegionV);
                 _shader.TextureWrapModeU = _textureWrapU;
                 _shader.TextureWrapModeV = _textureWrapV;
                 pass.Apply();

--- a/OpenKh.Engine.MonoGame/OpenKh.Engine.MonoGame.csproj
+++ b/OpenKh.Engine.MonoGame/OpenKh.Engine.MonoGame.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.Engine/Parsers/MdlxParser.cs
+++ b/OpenKh.Engine/Parsers/MdlxParser.cs
@@ -30,6 +30,19 @@ namespace OpenKh.Engine.Parsers
             B = (byte)clr;
             A = (byte)(clr >> 24);
         }
+
+        public PositionColoredTextured(Vector3 v, uint clr, float tu, float tv)
+        {
+            X = v.X;
+            Y = v.Y;
+            Z = v.Z;
+            Tu = tu;
+            Tv = tv;
+            R = (byte)(clr >> 16);
+            G = (byte)(clr >> 8);
+            B = (byte)clr;
+            A = (byte)(clr >> 24);
+        }
     }
 
     public class MeshDescriptor

--- a/OpenKh.Game/Infrastructure/Kh2Field.cs
+++ b/OpenKh.Game/Infrastructure/Kh2Field.cs
@@ -249,8 +249,8 @@ namespace OpenKh.Game.Infrastructure
             if (_isFreeCam == true)
                 return;
 
-            _camera.CameraPosition = new Vector3(position.X, position.Y, position.Z);
-            _camera.CameraLookAt = new Vector3(lookAt.X, lookAt.Y, lookAt.Z);
+            _camera.CameraPosition = new n.Vector3(position.X, position.Y, position.Z);
+            _camera.CameraLookAt = new n.Vector3(lookAt.X, lookAt.Y, lookAt.Z);
             _camera.FieldOfView = (float)(fieldOfView * Math.PI / 180);
         }
 
@@ -314,9 +314,9 @@ namespace OpenKh.Game.Infrastructure
                 _graphicsDevice.BlendState = BlendState.AlphaBlend;
 
                 _shader.UseAlphaMask = true;
-                _shader.ProjectionView = Matrix.Identity;
-                _shader.WorldView = Matrix.Identity;
-                _shader.ModelView = Matrix.Identity;
+                _shader.SetProjectionViewIdentity();
+                _shader.SetWorldViewIdentity();
+                _shader.SetModelViewIdentity();
                 pass.Apply();
 
                 _graphicsDevice.DrawUserPrimitives(

--- a/OpenKh.Game/States/MapState.cs
+++ b/OpenKh.Game/States/MapState.cs
@@ -290,9 +290,9 @@ namespace OpenKh.Game.States
                 if (currentInfo.PMO_Offset != 0)
                 {
                     PmpEntity pmpEnt = new PmpEntity(PmoIndex,
-                        new System.Numerics.Vector3(currentInfo.PositionX, currentInfo.PositionY, currentInfo.PositionZ),
-                        new System.Numerics.Vector3(currentInfo.RotationX, currentInfo.RotationY, currentInfo.RotationZ),
-                        new System.Numerics.Vector3(currentInfo.ScaleX, currentInfo.ScaleY, currentInfo.ScaleZ));
+                        new Vector3(currentInfo.PositionX, currentInfo.PositionY, currentInfo.PositionZ),
+                        new Vector3(currentInfo.RotationX, currentInfo.RotationY, currentInfo.RotationZ),
+                        new Vector3(currentInfo.ScaleX, currentInfo.ScaleY, currentInfo.ScaleZ));
 
                     pmpEnt.DifferentMatrix = pmp.hasDifferentMatrix[PmoIndex];
                     PmoParser pParser = new PmoParser(pmp.PmoList[PmoIndex], 100.0f);

--- a/OpenKh.Game/States/MapState.cs
+++ b/OpenKh.Game/States/MapState.cs
@@ -1,4 +1,3 @@
-using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using OpenKh.Bbs;
 using OpenKh.Common;
@@ -15,6 +14,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
+using xna = Microsoft.Xna.Framework;
 
 namespace OpenKh.Game.States
 {
@@ -28,7 +29,7 @@ namespace OpenKh.Game.States
             AlphaDestinationBlend = Blend.InverseSourceAlpha,
             ColorBlendFunction = BlendFunction.Add,
             AlphaBlendFunction = BlendFunction.Add,
-            BlendFactor = Color.White,
+            BlendFactor = xna.Color.White,
             MultiSampleMask = int.MaxValue,
             IndependentBlendEnable = false
         };
@@ -36,7 +37,7 @@ namespace OpenKh.Game.States
         public Kernel Kernel { get; private set; }
         private IDataContent _dataContent;
         private ArchiveManager _archiveManager;
-        private GraphicsDeviceManager _graphics;
+        private xna.GraphicsDeviceManager _graphics;
         private InputManager _input;
         private IStateChange _stateChange;
         private List<MeshGroup> _models = new List<MeshGroup>();
@@ -158,9 +159,9 @@ namespace OpenKh.Game.States
         {
             _graphics.GraphicsDevice.DepthStencilState = passRenderOpaque ? DepthStencilState.Default : DepthStencilState.DepthRead;
 
-            _shader.ProjectionView = _camera.Projection;
-            _shader.WorldView = _camera.World;
-            _shader.ModelView = Matrix.Identity;
+            _shader.SetProjectionView(_camera.Projection);
+            _shader.SetWorldView(_camera.World);
+            _shader.SetModelViewIdentity();
             pass.Apply();
 
             foreach (var mesh in _models)
@@ -172,9 +173,9 @@ namespace OpenKh.Game.States
 
             Field.ForEveryModel((entity, model) =>
             {
-                _shader.ProjectionView = _camera.Projection;
-                _shader.WorldView = _camera.World;
-                _shader.ModelView = entity.GetMatrix().ToXna();
+                _shader.SetProjectionView(_camera.Projection);
+                _shader.SetWorldView(_camera.World);
+                _shader.SetModelView(entity.GetMatrix());
                 pass.Apply();
 
                 RenderMeshNew(pass, model, passRenderOpaque);
@@ -182,9 +183,9 @@ namespace OpenKh.Game.States
 
             foreach (var entity in _bobEntities)
             {
-                _shader.ProjectionView = _camera.Projection;
-                _shader.WorldView = _camera.World;
-                _shader.ModelView = entity.GetMatrix().ToXna();
+                _shader.SetProjectionView(_camera.Projection);
+                _shader.SetWorldView(_camera.World);
+                _shader.SetModelView(entity.GetMatrix());
                 pass.Apply();
 
                 RenderMeshNew(pass, _bobModels[entity.BobIndex], passRenderOpaque);
@@ -194,7 +195,7 @@ namespace OpenKh.Game.States
             {
                 if (ent.DifferentMatrix)
                 {
-                    Matrix world = _camera.World;
+                    var world = _camera.World;
                     world.M14 = 0;
                     world.M24 = 0;
                     world.M34 = 0;
@@ -202,12 +203,12 @@ namespace OpenKh.Game.States
                     world.M42 = 0;
                     world.M43 = 0;
                     world.M44 = 1;
-                    _shader.WorldView = world;
+                    _shader.SetWorldView(ref world);
                     _graphics.GraphicsDevice.DepthStencilState = DepthStencilState.DepthRead;
                 }
                 else
                 {
-                    _shader.WorldView = _camera.World;
+                    _shader.SetWorldView(_camera.World);
                     _graphics.GraphicsDevice.DepthStencilState = DepthStencilState.Default;
                 }
 
@@ -226,8 +227,8 @@ namespace OpenKh.Game.States
                 }
 
 
-                _shader.ProjectionView = _camera.Projection;
-                _shader.ModelView = ent.GetMatrix().ToXna();
+                _shader.SetProjectionView(_camera.Projection);
+                _shader.SetModelView(ent.GetMatrix());
                 _shader.UseAlphaMask = true;
                 pass.Apply();
 

--- a/OpenKh.Tools.Common.CustomImGui/ImGuiEx.cs
+++ b/OpenKh.Tools.Common.CustomImGui/ImGuiEx.cs
@@ -144,7 +144,7 @@ namespace OpenKh.Tools.Common.CustomImGui
                     ImGuiWindowFlags.NoCollapse |
                     ImGuiWindowFlags.NoMove |
                     (noBackground ? ImGuiWindowFlags.NoBackground : ImGuiWindowFlags.None));
-                ImGui.SetWindowPos(new System.Numerics.Vector2(0, 0));
+                ImGui.SetWindowPos(new Vector2(0, 0));
                 ImGui.SetWindowSize(ImGui.GetIO().DisplaySize);
                 return ret;
             }, ImGui.End, action);

--- a/OpenKh.Tools.Kh2MapStudio/App.cs
+++ b/OpenKh.Tools.Kh2MapStudio/App.cs
@@ -366,26 +366,26 @@ namespace OpenKh.Tools.Kh2MapStudio
 
             var camera = _mapRenderer.Camera;
             if (keyboard.IsKeyDown(Keys.W))
-                camera.CameraPosition += xna.Vector3.Multiply(camera.CameraLookAtX, moveSpeed * 5);
+                camera.CameraPosition += Vector3.Multiply(camera.CameraLookAtX, moveSpeed * 5);
             if (keyboard.IsKeyDown(Keys.S))
-                camera.CameraPosition -= xna.Vector3.Multiply(camera.CameraLookAtX, moveSpeed * 5);
+                camera.CameraPosition -= Vector3.Multiply(camera.CameraLookAtX, moveSpeed * 5);
             if (keyboard.IsKeyDown(Keys.A))
-                camera.CameraPosition -= xna.Vector3.Multiply(camera.CameraLookAtY, moveSpeed * 5);
+                camera.CameraPosition -= Vector3.Multiply(camera.CameraLookAtY, moveSpeed * 5);
             if (keyboard.IsKeyDown(Keys.D))
-                camera.CameraPosition += xna.Vector3.Multiply(camera.CameraLookAtY, moveSpeed * 5);
+                camera.CameraPosition += Vector3.Multiply(camera.CameraLookAtY, moveSpeed * 5);
             if (keyboard.IsKeyDown(Keys.Q))
-                camera.CameraPosition += xna.Vector3.Multiply(camera.CameraLookAtZ, moveSpeed * 5);
+                camera.CameraPosition += Vector3.Multiply(camera.CameraLookAtZ, moveSpeed * 5);
             if (keyboard.IsKeyDown(Keys.E))
-                camera.CameraPosition -= xna.Vector3.Multiply(camera.CameraLookAtZ, moveSpeed * 5);
+                camera.CameraPosition -= Vector3.Multiply(camera.CameraLookAtZ, moveSpeed * 5);
 
             if (keyboard.IsKeyDown(Keys.Up))
-                camera.CameraRotationYawPitchRoll += new xna.Vector3(0, 0, 1 * speed);
+                camera.CameraRotationYawPitchRoll += new Vector3(0, 0, 1 * speed);
             if (keyboard.IsKeyDown(Keys.Down))
-                camera.CameraRotationYawPitchRoll -= new xna.Vector3(0, 0, 1 * speed);
+                camera.CameraRotationYawPitchRoll -= new Vector3(0, 0, 1 * speed);
             if (keyboard.IsKeyDown(Keys.Left))
-                camera.CameraRotationYawPitchRoll += new xna.Vector3(1 * speed, 0, 0);
+                camera.CameraRotationYawPitchRoll += new Vector3(1 * speed, 0, 0);
             if (keyboard.IsKeyDown(Keys.Right))
-                camera.CameraRotationYawPitchRoll -= new xna.Vector3(1 * speed, 0, 0);
+                camera.CameraRotationYawPitchRoll -= new Vector3(1 * speed, 0, 0);
         }
 
         private void ProcessMouseInput(MouseState mouse)
@@ -396,8 +396,8 @@ namespace OpenKh.Tools.Kh2MapStudio
                 var camera = _mapRenderer.Camera;
                 var xSpeed = (_previousMousePosition.X - mouse.Position.X) * Speed;
                 var ySpeed = (_previousMousePosition.Y - mouse.Position.Y) * Speed;
-                camera.CameraRotationYawPitchRoll += new xna.Vector3(1 * xSpeed, 0, 0);
-                camera.CameraRotationYawPitchRoll += new xna.Vector3(0, 0, 1 * ySpeed);
+                camera.CameraRotationYawPitchRoll += new Vector3(1 * xSpeed, 0, 0);
+                camera.CameraRotationYawPitchRoll += new Vector3(0, 0, 1 * ySpeed);
             }
 
             _previousMousePosition = mouse.Position;

--- a/OpenKh.Tools.Kh2MapStudio/Windows/CameraWindow.cs
+++ b/OpenKh.Tools.Kh2MapStudio/Windows/CameraWindow.cs
@@ -1,5 +1,5 @@
-using Microsoft.Xna.Framework;
 using OpenKh.Engine.MonoGame;
+using System.Numerics;
 using static OpenKh.Tools.Common.CustomImGui.ImGuiEx;
 using static OpenKh.Tools.Kh2MapStudio.ImGuiExHelpers;
 


### PR DESCRIPTION
To manage matrices and vectors, we currently have both `System.Numerics` and `Microsoft.Xna.Framework`. `System.Numerics` is faster and with the latest versions of .NET Core, the compiler can generate specialised instructions for certain processors to boost performance even more. But `Microsoft.Xna.Framework`, which is part of MonoGame, have basically the same functionality but slower.

This PR aims to remove some overhead caused by the MonoGame library, to standardise the math library following the .NET Core specifications and to remove the dependency of it here and there.