### PR TITLE
Vertices uses float colors to simulate bloom effect

### DIFF
--- a/OpenKh.Command.PmoConverter/Program.cs
+++ b/OpenKh.Command.PmoConverter/Program.cs
@@ -106,10 +106,10 @@ namespace OpenKh.Command.PmoConverter
                 // Set extra flags.
                 if (UsesUniformColor)
                 {
-                    uint UniformColor = (byte)(desc.Vertices[0].A * 2.0f);
-                    UniformColor += desc.Vertices[0].B * (uint)0x200;
-                    UniformColor += desc.Vertices[0].G * (uint)0x20000;
-                    UniformColor += desc.Vertices[0].R * (uint)0x2000000;
+                    var UniformColor = (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].A) * 2f);
+                    UniformColor += (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].B)) << 8;
+                    UniformColor += (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].G)) << 16;
+                    UniformColor += (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].R)) << 24;
                     chunk.SectionInfo.VertexFlags = BitsUtil.Int.SetBit(chunk.SectionInfo.VertexFlags, 24, true);
                     chunk.SectionInfo_opt2 = new Pmo.MeshSectionOptional2();
                     chunk.SectionInfo_opt2.DiffuseColor = UniformColor;
@@ -322,10 +322,10 @@ namespace OpenKh.Command.PmoConverter
                             vertices[i].Z = x.Vertices[i].Z * Scale;
                             vertices[i].Tu = x.TextureCoordinateChannels[0][i].X;
                             vertices[i].Tv = 1.0f - x.TextureCoordinateChannels[0][i].Y;
-                            vertices[i].R = 0xFF;
-                            vertices[i].G = 0xFF;
-                            vertices[i].B = 0xFF;
-                            vertices[i].A = 0xFF;
+                            vertices[i].R = 1.0f;
+                            vertices[i].G = 1.0f;
+                            vertices[i].B = 1.0f;
+                            vertices[i].A = 1.0f;
                         }
 
                         return new MeshDescriptor

--- a/OpenKh.Command.PmoConverter/Program.cs
+++ b/OpenKh.Command.PmoConverter/Program.cs
@@ -106,10 +106,10 @@ namespace OpenKh.Command.PmoConverter
                 // Set extra flags.
                 if (UsesUniformColor)
                 {
-                    var UniformColor = (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].A) * 2f);
-                    UniformColor += (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].B)) << 8;
-                    UniformColor += (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].G)) << 16;
-                    UniformColor += (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].R)) << 24;
+                    var UniformColor = (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].A * 256f));
+                    UniformColor += (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].B * 256f)) << 8;
+                    UniformColor += (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].G * 256f)) << 16;
+                    UniformColor += (uint)(Math.Min(byte.MaxValue, desc.Vertices[0].R * 256f)) << 24;
                     chunk.SectionInfo.VertexFlags = BitsUtil.Int.SetBit(chunk.SectionInfo.VertexFlags, 24, true);
                     chunk.SectionInfo_opt2 = new Pmo.MeshSectionOptional2();
                     chunk.SectionInfo_opt2.DiffuseColor = UniformColor;

--- a/OpenKh.Command.PmpConverter/Program.cs
+++ b/OpenKh.Command.PmpConverter/Program.cs
@@ -114,10 +114,10 @@ namespace OpenKh.Command.PmpConverter
                     // Set extra flags.
                     if (UsesUniformColor)
                     {
-                        uint UniformColor = desc.Vertices[0].A;
-                        UniformColor += desc.Vertices[0].B * (uint)0x100;
-                        UniformColor += desc.Vertices[0].G * (uint)0x10000;
-                        UniformColor += desc.Vertices[0].R * (uint)0x1000000;
+                        var UniformColor = (uint)(desc.Vertices[0].A / 255f);
+                        UniformColor += (uint)(desc.Vertices[0].B / 255f) << 8;
+                        UniformColor += (uint)(desc.Vertices[0].G / 255f) << 16;
+                        UniformColor += (uint)(desc.Vertices[0].R / 255f) << 24;
                         chunk.SectionInfo.VertexFlags = BitsUtil.Int.SetBit(chunk.SectionInfo.VertexFlags, 24, true);
                         chunk.SectionInfo_opt2 = new Pmo.MeshSectionOptional2();
                         chunk.SectionInfo_opt2.DiffuseColor = UniformColor;

--- a/OpenKh.Engine.MonoGame/MeshLoader.cs
+++ b/OpenKh.Engine.MonoGame/MeshLoader.cs
@@ -1,4 +1,3 @@
-using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using OpenKh.Engine.Motion;
 using OpenKh.Engine.Parsers;
@@ -11,11 +10,11 @@ namespace OpenKh.Engine.MonoGame
     public static class MeshLoader
     {
         public static VertexDeclaration PositionColoredTexturedVertexDeclaration =
-            new VertexDeclaration(24, new VertexElement[]
+            new VertexDeclaration(36, new VertexElement[]
             {
                 new VertexElement(0, VertexElementFormat.Vector3, VertexElementUsage.Position, 0),
                 new VertexElement(12, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 0),
-                new VertexElement(20, VertexElementFormat.Color, VertexElementUsage.Color, 0),
+                new VertexElement(20, VertexElementFormat.Vector4, VertexElementUsage.Color, 0),
             });
 
         public static IModelMotion FromKH2(Mdlx model) =>

--- a/OpenKh.Engine/Parsers/Kkdf2MdlxParser.cs
+++ b/OpenKh.Engine/Parsers/Kkdf2MdlxParser.cs
@@ -220,10 +220,11 @@ namespace OpenKh.Engine.Parsers
                     for (int i = 0; i < triRef.list.Length; i++)
                     {
                         VertexRef vertRef = triRef.list[i];
-                        Vector3 pos = immutableExportedMesh.positionList[vertRef.vertexIndex];
-                        Vector2 uv = immutableExportedMesh.uvList[vertRef.uvIndex];
                         indices.Add(vertices.Count);
-                        vertices.Add(new PositionColoredTextured(pos, -1, uv.X, uv.Y));
+                        vertices.Add(new PositionColoredTextured(
+                            immutableExportedMesh.positionList[vertRef.vertexIndex],
+                            immutableExportedMesh.uvList[vertRef.uvIndex],
+                            1.0f, 1.0f, 1.0f, 1.0f));
                     }
                 }
 

--- a/OpenKh.Engine/Parsers/MdlxParser.cs
+++ b/OpenKh.Engine/Parsers/MdlxParser.cs
@@ -11,37 +11,37 @@ using System.Runtime.InteropServices;
 
 namespace OpenKh.Engine.Parsers
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
     public struct PositionColoredTextured
     {
         public float X, Y, Z;
         public float Tu, Tv;
-        public byte R, G, B, A;
+        public float R, G, B, A;
 
-        public PositionColoredTextured(Vector3 v, int clr, float tu, float tv)
+        public PositionColoredTextured(float x, float y, float z, float tu, float tv, float r, float g, float b, float a)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
+            X = x;
+            Y = y;
+            Z = z;
             Tu = tu;
             Tv = tv;
-            R = (byte)(clr >> 16);
-            G = (byte)(clr >> 8);
-            B = (byte)clr;
-            A = (byte)(clr >> 24);
+            R = r;
+            G = g;
+            B = b;
+            A = a;
         }
 
-        public PositionColoredTextured(Vector3 v, uint clr, float tu, float tv)
+        public PositionColoredTextured(Vector3 pos, Vector2 uv, float r, float g, float b, float a)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
-            Tu = tu;
-            Tv = tv;
-            R = (byte)(clr >> 16);
-            G = (byte)(clr >> 8);
-            B = (byte)clr;
-            A = (byte)(clr >> 24);
+            X = pos.X;
+            Y = pos.Y;
+            Z = pos.Z;
+            Tu = uv.X;
+            Tv = uv.Y;
+            R = r;
+            G = g;
+            B = b;
+            A = a;
         }
     }
 
@@ -125,13 +125,16 @@ namespace OpenKh.Engine.Parsers
                         colorA = 0x80;
                     }
 
-                    var color = Math.Min(byte.MaxValue, colorB * 2) |
-                        (Math.Min(byte.MaxValue, colorG * 2) << 8) |
-                        (Math.Min(byte.MaxValue, colorR * 2) << 16) |
-                        (Math.Min(byte.MaxValue, colorA * 2) << 24);
-
                     vertices.Add(new PositionColoredTextured(
-                        position, color, (short)(ushort)vertexIndex.U / 4096.0f, (short)(ushort)vertexIndex.V / 4096.0f));
+                        vpu.Vertices[vertexIndex.Index].X,
+                        vpu.Vertices[vertexIndex.Index].Y,
+                        vpu.Vertices[vertexIndex.Index].Z,
+                        (short)(ushort)vertexIndex.U / 4096.0f,
+                        (short)(ushort)vertexIndex.V / 4096.0f,
+                        colorR / 128f,
+                        colorG / 128f,
+                        colorB / 128f,
+                        colorA / 128f));
 
                     indexBuffer[(recentIndex++) & 3] = baseVertexIndex + i;
                     switch (vertexIndex.Function)

--- a/OpenKh.Engine/Parsers/PmoParser.cs
+++ b/OpenKh.Engine/Parsers/PmoParser.cs
@@ -26,19 +26,19 @@ namespace OpenKh.Engine.Parsers
 
                     if(Pmo.GetFlags(pmo.Meshes[x].SectionInfo).UniformDiffuseFlag)
                     {
-                        byte[] byt = BitConverter.GetBytes(pmo.Meshes[x].SectionInfo_opt2.DiffuseColor);
+                        var colorData = BitConverter.GetBytes(pmo.Meshes[x].SectionInfo_opt2.DiffuseColor);
 
-                        color.X = byt[0];
-                        color.Y = byt[1];
-                        color.Z = byt[2];
-                        color.W = byt[3];
+                        color.X = colorData[0] / 255f;
+                        color.Y = colorData[1] / 255f;
+                        color.Z = colorData[2] / 255f;
+                        color.W = colorData[3] / 255f;
                     }
                     else
                     {
-                        color.X = pmo.Meshes[x].colors[i].X;
-                        color.Y = pmo.Meshes[x].colors[i].Y;
-                        color.Z = pmo.Meshes[x].colors[i].Z;
-                        color.W = pmo.Meshes[x].colors[i].W;
+                        color.X = pmo.Meshes[x].colors[i].X / 255f;
+                        color.Y = pmo.Meshes[x].colors[i].Y / 255f;
+                        color.Z = pmo.Meshes[x].colors[i].Z / 255f;
+                        color.W = pmo.Meshes[x].colors[i].W / 255f;
                     }
 
                     vertices[i].X = pmo.Meshes[x].vertices[i].X * pmo.header.ModelScale * Scale;
@@ -46,10 +46,10 @@ namespace OpenKh.Engine.Parsers
                     vertices[i].Z = pmo.Meshes[x].vertices[i].Z * pmo.header.ModelScale * Scale;
                     vertices[i].Tu = pmo.Meshes[x].textureCoordinates[i].X;
                     vertices[i].Tv = pmo.Meshes[x].textureCoordinates[i].Y;
-                    vertices[i].R = (byte)color.X;
-                    vertices[i].G = (byte)color.Y;
-                    vertices[i].B = (byte)color.Z;
-                    vertices[i].A = (byte)color.W;
+                    vertices[i].R = color.X;
+                    vertices[i].G = color.Y;
+                    vertices[i].B = color.Z;
+                    vertices[i].A = color.W;
                 }
 
                 currentMesh = new MeshDescriptor()

--- a/OpenKh.Game/Entities/ObjectEntity.cs
+++ b/OpenKh.Game/Entities/ObjectEntity.cs
@@ -131,10 +131,10 @@ namespace OpenKh.Game.Entities
                             vertices[i].Z = x.Vertices[i].Z * Scale;
                             vertices[i].Tu = x.TextureCoordinateChannels[0][i].X;
                             vertices[i].Tv = 1.0f - x.TextureCoordinateChannels[0][i].Y;
-                            vertices[i].R = 0xFF;
-                            vertices[i].G = 0xFF;
-                            vertices[i].B = 0xFF;
-                            vertices[i].A = 0xFF;
+                            vertices[i].R = 1.0f;
+                            vertices[i].G = 1.0f;
+                            vertices[i].B = 1.0f;
+                            vertices[i].A = 1.0f;
                         }
 
                         return new MeshDescriptor

--- a/OpenKh.Tools.Kh2MapStudio/MapRenderer.cs
+++ b/OpenKh.Tools.Kh2MapStudio/MapRenderer.cs
@@ -331,14 +331,14 @@ namespace OpenKh.Tools.Kh2MapStudio
                             var color = new xna.Color(1f, 0f, 0f, .5f);
                             var vertices = new PositionColoredTextured[]
                             {
-                                new PositionColoredTextured(new Vector3(-1, -1, -1), 0x800000FFU, 0, 0),
-                                new PositionColoredTextured(new Vector3(+1, -1, -1), 0x800000FFU, 0, 0),
-                                new PositionColoredTextured(new Vector3(+1, +1, -1), 0x800000FFU, 0, 0),
-                                new PositionColoredTextured(new Vector3(-1, +1, -1), 0x800000FFU, 0, 0),
-                                new PositionColoredTextured(new Vector3(-1, -1, +1), 0x800000FFU, 0, 0),
-                                new PositionColoredTextured(new Vector3(+1, -1, +1), 0x800000FFU, 0, 0),
-                                new PositionColoredTextured(new Vector3(+1, +1, +1), 0x800000FFU, 0, 0),
-                                new PositionColoredTextured(new Vector3(-1, +1, +1), 0x800000FFU, 0, 0),
+                                new PositionColoredTextured(-1, -1, -1, 0, 0, 1f, 0f, 0f, 1f),
+                                new PositionColoredTextured(+1, -1, -1, 0, 0, 1f, 0f, 0f, 1f),
+                                new PositionColoredTextured(+1, +1, -1, 0, 0, 1f, 0f, 0f, 1f),
+                                new PositionColoredTextured(-1, +1, -1, 0, 0, 1f, 0f, 0f, 1f),
+                                new PositionColoredTextured(-1, -1, +1, 0, 0, 1f, 0f, 0f, 1f),
+                                new PositionColoredTextured(+1, -1, +1, 0, 0, 1f, 0f, 0f, 1f),
+                                new PositionColoredTextured(+1, +1, +1, 0, 0, 1f, 0f, 0f, 1f),
+                                new PositionColoredTextured(-1, +1, +1, 0, 0, 1f, 0f, 0f, 1f),
                             };
                             var indices = new int[]
                             {


### PR DESCRIPTION
[As already mentioned](https://discord.com/channels/409140906625728532/735110384398106694/804270502821888001), it fixes an issue [mentioned in discord](https://discord.com/channels/409140906625728532/567065170879184910/799395407163031552) to simulate a [known behaviour](https://discord.com/channels/409140906625728532/565971398539870273/784232466985779240) in Kingdom Hearts games.
