### PR TITLE
Fix build script when running twice

### DIFF
--- a/OpenKh.WinShell.IMDUtilities/OpenKh.WinShell.IMDUtilities.csproj
+++ b/OpenKh.WinShell.IMDUtilities/OpenKh.WinShell.IMDUtilities.csproj
@@ -2,7 +2,7 @@
 
    <PropertyGroup>
      <TargetFramework>net472</TargetFramework>
-     <OutputPath>..\OpenKh.WinShell.Output\</OutputPath>
+     <OutputPath>..\bin\WinShell\</OutputPath>
    </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.WinShell.IMZUtilities/OpenKh.WinShell.IMZUtilities.csproj
+++ b/OpenKh.WinShell.IMZUtilities/OpenKh.WinShell.IMZUtilities.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
       <TargetFramework>net472</TargetFramework>
-      <OutputPath>..\OpenKh.WinShell.Output\</OutputPath>
+      <OutputPath>..\bin\WinShell\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/tool/GUI.ImageViewer/index.md
+++ b/docs/tool/GUI.ImageViewer/index.md
@@ -12,6 +12,8 @@ Honestly, there really isn't much to say. The OpenKH Image Viewer is capable of 
 
 Currently the program only supports exporting the image, but import functions are well on the way. At the bottom of the program you will notice several details. You can set the scale factor so the image fits the size of the window or select static percentages based on the actual image proportions, and in the case of IMZ (stacked IMD files effectively zipped into one handy file, complete with a cute little bow) you can even select sub-images within to view. Additionally, there are other minor details such as the specific image dimensions and the color palette.
 
-That about wraps up this document for now.
-
 <img src="./viewer.png">
+
+## View and convert from Windows Explorer
+
+It is possible to preview images without opening them via Image Viewer straight from Windows. To achieve that, please follow the [WinShell set-up guide](../winshell/index.md).

--- a/docs/tool/winshell/index.md
+++ b/docs/tool/winshell/index.md
@@ -4,10 +4,11 @@ In order to allow many quality of life improvements to aid in modding Kingdom He
 These WinShell extensions negate the need to navigate through a tool for the most basic operations you can do with Kingdom Hearts files.
 
 Currently, the extensions you see below are the extensions we have within the project:
+
 - OpenKh.WinShell.IMDUtilities -> Provides thumbnail generation for IMD files and quick conversion of them to PNG.
 - OpenKh.WinShell.IMZUtilities -> Provides ease of extraction and repack for IMZ files.
 
-# Installation
+## Installation
 
 All OpenKh.WinShell libraries are powered by SharpShell. So their installation is not standard, but is easy to do none-the-less. 
 To install these extensions, download the SharpShell ServerManager from [this link](https://github.com/dwmkerr/sharpshell/releases).
@@ -16,7 +17,7 @@ Afterwards, open the ServerManager (you need Administrator Privileges for this).
 
 ![ServerManager Main Screen](https://i.imgur.com/VpByIAO.png)
 
-Click on "**File -> Load Server...**", and click on the WinShell extensions you want to load (In our case, "**OpenKh.WinShell.IMDUtilities.dll**")
+Click on "**File -> Load Server...**", and click on the WinShell extensions you want to load (In our case, **OpenKh.WinShell.IMDUtilities.dll** found in `bin/WinShell`)
 
 Afterwards, you should see a screen like this:
 


### PR DESCRIPTION
Basically redirects the `OpenKh.Winshell.Output` into `./bin` folder so it does not obstruct the `build.ps1` script. I modified the documentation of WinShell acoordingly other than indexing it on the docs.