### PR TITLE
Add ListReplace patching method and tests

### DIFF
--- a/OpenKh.Kh2/SystemData/Item.cs
+++ b/OpenKh.Kh2/SystemData/Item.cs
@@ -79,8 +79,8 @@ namespace OpenKh.Kh2.SystemData
             [Data] public byte Unknown { get; set; }
         }
 
-        [Data] public List<Entry> Items1 { get; set; }
-        [Data] public List<Stat> Items2 { get; set; }
+        [Data] public List<Entry> Items { get; set; }
+        [Data] public List<Stat> Stats { get; set; }
 
         public static Item Read(Stream stream)
         {
@@ -90,15 +90,15 @@ namespace OpenKh.Kh2.SystemData
 
             return new Item
             {
-                Items1 = one,
-                Items2 = two
+                Items = one,
+                Stats = two
             };
         }
 
         public void Write(Stream stream)
         {
-            BaseTable<Entry>.Write(stream, 6, Items1);
-            BaseTable<Stat>.Write(stream, 0, Items2);
+            BaseTable<Entry>.Write(stream, 6, Items);
+            BaseTable<Stat>.Write(stream, 0, Stats);
         }
     }
 }

--- a/OpenKh.Patcher/FmlvDTO.cs
+++ b/OpenKh.Patcher/FmlvDTO.cs
@@ -2,13 +2,10 @@ namespace OpenKh.Patcher
 {
     public class FmlvDTO
     {
-        public int Unk0;
-        public byte LevelGrowthAbility;
+        public byte GrowthAbilityLevel;
         public short Ability;
-        public int Exp;
-        public int FormId;
+        public int Experience;
         public int FormLevel;
-        public OpenKh.Kh2.Battle.Fmlv.FormVanilla FormVanilla;
-        public OpenKh.Kh2.Battle.Fmlv.FormFm FormFm;
+
     }
 }

--- a/OpenKh.Patcher/FmlvDTO.cs
+++ b/OpenKh.Patcher/FmlvDTO.cs
@@ -1,0 +1,14 @@
+namespace OpenKh.Patcher
+{
+    public class FmlvDTO
+    {
+        public int Unk0;
+        public byte LevelGrowthAbility;
+        public short Ability;
+        public int Exp;
+        public int FormId;
+        public int FormLevel;
+        public OpenKh.Kh2.Battle.Fmlv.FormVanilla FormVanilla;
+        public OpenKh.Kh2.Battle.Fmlv.FormFm FormFm;
+    }
+}

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -381,6 +381,18 @@ namespace OpenKh.Patcher
                             Kh2.Battle.Bons.Write(stream.SetPosition(0), bonusList.Values);
                             break;
 
+                        case "objentry":
+                            var objEntryList = Kh2.Objentry.Read(stream).ToDictionary(x => x.ObjectId, x=>x);
+                            var serializer = new Serializer().Serialize(objEntryList);
+                            File.WriteAllText(context.GetSourceModAssetPath("objentry.yml"), serializer);
+                            var moddedObjEntry = deserializer.Deserialize<Dictionary<uint, Kh2.Objentry>>(sourceText);
+                            foreach (var objEntry in moddedObjEntry)
+                            {
+                                objEntryList[objEntry.Key] = objEntry.Value;
+                            }
+                            Kh2.Objentry.Write(stream.SetPosition(0), objEntryList.Values);
+                            break;
+
                         default:
                             break;
                     }

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -300,10 +300,10 @@ namespace OpenKh.Patcher
                     {
                         case "trsr":
                             var trsrList = Kh2.SystemData.Trsr.Read(stream).ToDictionary(x => x.Id, x => x);
-                            var moddedTrsr = deserializer.Deserialize<Dictionary<int, Kh2.SystemData.Trsr>>(sourceText);
+                            var moddedTrsr = deserializer.Deserialize<Dictionary<ushort, Kh2.SystemData.Trsr>>(sourceText);
                             foreach (var treasure in moddedTrsr)
                             {
-                                trsrList[treasure.Value.Id].ItemId = treasure.Value.ItemId;
+                                trsrList[treasure.Key].ItemId = treasure.Value.ItemId;
                             }
                                 Kh2.SystemData.Trsr.Write(stream.SetPosition(0), trsrList.Values);
                             break;

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -311,22 +311,28 @@ namespace OpenKh.Patcher
                         case "item":
                             var itemList = Kh2.SystemData.Item.Read(stream);
                             var moddedItem = deserializer.Deserialize<Kh2.SystemData.Item>(sourceText);
-                             foreach (var item in moddedItem.Items1)
-                             {
-                                var itemToUpdate = itemList.Items1.FirstOrDefault(x => x.Id == item.Id);
-                                if (itemToUpdate != null)
+                            if (moddedItem.Items1 != null)
+                            {
+                                foreach (var item in moddedItem.Items1)
                                 {
-                                    itemList.Items1[itemList.Items1.IndexOf(itemToUpdate)] = item;
+                                    var itemToUpdate = itemList.Items1.FirstOrDefault(x => x.Id == item.Id);
+                                    if (itemToUpdate != null)
+                                    {
+                                        itemList.Items1[itemList.Items1.IndexOf(itemToUpdate)] = item;
+                                    }
                                 }
-                             }
-                             foreach (var item in moddedItem.Items2)
-                             {
-                                var itemToUpdate = itemList.Items2.FirstOrDefault(x => x.Id == item.Id);
-                                if (itemToUpdate != null)
+                            }
+                            if (moddedItem.Items2 != null)
+                            {
+                                foreach (var item in moddedItem.Items2)
                                 {
-                                    itemList.Items2[itemList.Items2.IndexOf(itemToUpdate)] = item;
+                                    var itemToUpdate = itemList.Items2.FirstOrDefault(x => x.Id == item.Id);
+                                    if (itemToUpdate != null)
+                                    {
+                                        itemList.Items2[itemList.Items2.IndexOf(itemToUpdate)] = item;
+                                    }
                                 }
-                             }
+                            }
                             itemList.Write(stream.SetPosition(0));
                             break;
 
@@ -342,36 +348,36 @@ namespace OpenKh.Patcher
                                 formList[form.FinalMixForm].Add(form);
                             }
                             var moddedForms = deserializer.Deserialize<Dictionary<Kh2.Battle.Fmlv.FormFm, List<Kh2.Battle.Fmlv>>>(sourceText);
-                            foreach (var form in moddedForms)
-                            {
-                                foreach (var level in form.Value)
+                                foreach (var form in moddedForms)
                                 {
-                                    formList[form.Key][level.FormLevel - 1] = level;
-                                }
+                                    foreach (var level in form.Value)
+                                    {
+                                        formList[form.Key][level.FormLevel - 1] = level;
+                                    }
 
-                            }
+                                }
                             Kh2.Battle.Fmlv.Write(stream.SetPosition(0), formList.Values.SelectMany(x=>x).ToList());
                             break;
 
                         case "lvup":
                             var levelList = Kh2.Battle.Lvup.Read(stream);
                             var moddedLevels = deserializer.Deserialize<Kh2.Battle.Lvup>(sourceText);
-                            int i = 0;
-                            foreach (var character in moddedLevels.Characters)
-                            {
-                                levelList.Characters[i].Levels = character.Levels;
-                                i++;
-                            }
+                                int i = 0;
+                                foreach (var character in moddedLevels.Characters)
+                                {
+                                    levelList.Characters[i].Levels = character.Levels;
+                                    i++;
+                                }
                             levelList.Write(stream.SetPosition(0));
                             break;
 
                         case "bons":
                             var bonusList = Kh2.Battle.Bons.Read(stream).ToDictionary(x => String.Concat(x.RewardId, characterMap.FirstOrDefault(y => y.Value == x.CharacterId).Key), x => x);
                             var moddedBonus = deserializer.Deserialize<Dictionary<string, Kh2.Battle.Bons>>(sourceText);
-                            foreach (var bonus in moddedBonus)
-                            {
-                                bonusList[bonus.Key] = bonus.Value;
-                            }
+                                foreach (var bonus in moddedBonus)
+                                {
+                                    bonusList[bonus.Key] = bonus.Value;
+                                }
                             Kh2.Battle.Bons.Write(stream.SetPosition(0), bonusList.Values);
                             break;
 

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -364,13 +364,16 @@ namespace OpenKh.Patcher
 
                         case "lvup":
                             var levelList = Kh2.Battle.Lvup.Read(stream);
-                            var moddedLevels = deserializer.Deserialize<Kh2.Battle.Lvup>(sourceText);
-                                int i = 0;
-                                foreach (var character in moddedLevels.Characters)
+                            var moddedLevels = deserializer.Deserialize<Dictionary<string, Dictionary<int, Kh2.Battle.Lvup.PlayableCharacter.Level>>> (sourceText);
+
+                            foreach (var character in moddedLevels)
+                            {
+                                foreach (var level in moddedLevels[character.Key])
                                 {
-                                    levelList.Characters[i].Levels = character.Levels;
-                                    i++;
+                                    levelList.Characters[characterMap[character.Key] - 1].Levels[level.Key - 1] = moddedLevels[character.Key][level.Key];
                                 }
+                            }   
+
                             levelList.Write(stream.SetPosition(0));
                             break;
 

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -305,7 +305,14 @@ namespace OpenKh.Patcher
                             {
                                 if (trsrList.ContainsKey(treasure.Key))
                                 {
-                                    trsrList[treasure.Key].ItemId = treasure.Value.ItemId;
+                                    if (treasure.Value.World == 0)
+                                    {
+                                        trsrList[treasure.Key].ItemId = treasure.Value.ItemId;
+                                    }
+                                    else
+                                    {
+                                        trsrList[treasure.Key] = treasure.Value;
+                                    } 
                                 }
                                 else
                                 {

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -338,21 +338,24 @@ namespace OpenKh.Patcher
 
                         case "fmlv":
                             var formRaw = Kh2.Battle.Fmlv.Read(stream).ToList();
-                            var formList = new Dictionary<Kh2.Battle.Fmlv.FormFm, List<Kh2.Battle.Fmlv>>();
+                            var formList = new Dictionary<Kh2.Battle.Fmlv.FormFm, List<Kh2.Battle.Fmlv.Level>>();
                             foreach (var form in formRaw)
                             {
-                                if (!formList.ContainsKey(form.FinalMixForm))
+                                if (!formList.ContainsKey(form.FormFm))
                                 {
-                                    formList.Add(form.FinalMixForm, new List<Kh2.Battle.Fmlv>());
+                                    formList.Add(form.FormFm, new List<Kh2.Battle.Fmlv.Level>());
                                 }
-                                formList[form.FinalMixForm].Add(form);
+                                formList[form.FormFm].Add(form);
                             }
-                            var moddedForms = deserializer.Deserialize<Dictionary<Kh2.Battle.Fmlv.FormFm, List<Kh2.Battle.Fmlv>>>(sourceText);
+                            var moddedForms = deserializer.Deserialize<Dictionary<Kh2.Battle.Fmlv.FormFm, List<FmlvDTO>>>(sourceText);
                                 foreach (var form in moddedForms)
                                 {
                                     foreach (var level in form.Value)
                                     {
-                                        formList[form.Key][level.FormLevel - 1] = level;
+                                        formList[level.FormFm][level.FormLevel - 1].Ability = level.Ability;
+                                        formList[level.FormFm][level.FormLevel - 1].Exp = level.Exp;
+                                        formList[level.FormFm][level.FormLevel - 1].LevelGrowthAbility = level.LevelGrowthAbility;
+                                        
                                     }
 
                                 }

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -285,14 +285,16 @@ namespace OpenKh.Patcher
             Kh2.Ard.AreaDataScript.Write(stream.SetPosition(0), scripts.Values);
         }
 
+        private static readonly Dictionary<string, byte> characterMap = new Dictionary<string, byte>(){
+            { "Sora", 1 }, { "Donald", 2 }, { "Goofy", 3 },  { "Mickey", 4 },  { "Auron", 5 }, { "PingMulan",6 }, { "Aladdin", 7 },  { "Sparrow", 8 }, { "Beast", 9 },  { "Jack", 10 },  { "Simba", 11 }, { "Tron", 12 }, { "Riku", 13 }, { "Roxas", 14} 
+        };
+
+        private static readonly IDeserializer deserializer = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
+            
         private static void PatchListReplace(Context context, List<AssetFile> sources, Stream stream)
         {
             foreach (var source in sources)
             {
-                var deserializer = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
-                Dictionary<string, byte> characterMap = new Dictionary<string, byte>() {
-                            { "Sora", 1 }, { "Donald", 2 }, { "Goofy", 3 },  { "Mickey", 4 },  { "Auron", 5 }, { "PingMulan",6 }, { "Aladdin", 7 },  { "Sparrow", 8 }, { "Beast", 9 },  { "Jack", 10 },  { "Simba", 11 }, { "Tron", 12 }, { "Riku", 13 }, { "Roxas", 14}
-                        };
                     string sourceText = File.ReadAllText(context.GetSourceModAssetPath(source.Name));
                     if (source.Name.Contains("enc"))
                     {

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -296,11 +296,6 @@ namespace OpenKh.Patcher
             foreach (var source in sources)
             {
                     string sourceText = File.ReadAllText(context.GetSourceModAssetPath(source.Name));
-                    if (source.Name.Contains("enc"))
-                    {
-                        byte[] data = System.Convert.FromBase64String(sourceText);
-                        sourceText = System.Text.ASCIIEncoding.ASCII.GetString(data);
-                    }
                     switch (source.Type)
                     {
                         case "trsr":

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -383,8 +383,6 @@ namespace OpenKh.Patcher
 
                         case "objentry":
                             var objEntryList = Kh2.Objentry.Read(stream).ToDictionary(x => x.ObjectId, x=>x);
-                            var serializer = new Serializer().Serialize(objEntryList);
-                            File.WriteAllText(context.GetSourceModAssetPath("objentry.yml"), serializer);
                             var moddedObjEntry = deserializer.Deserialize<Dictionary<uint, Kh2.Objentry>>(sourceText);
                             foreach (var objEntry in moddedObjEntry)
                             {

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -303,7 +303,15 @@ namespace OpenKh.Patcher
                             var moddedTrsr = deserializer.Deserialize<Dictionary<ushort, Kh2.SystemData.Trsr>>(sourceText);
                             foreach (var treasure in moddedTrsr)
                             {
-                                trsrList[treasure.Key].ItemId = treasure.Value.ItemId;
+                                if (trsrList.ContainsKey(treasure.Key))
+                                {
+                                    trsrList[treasure.Key].ItemId = treasure.Value.ItemId;
+                                }
+                                else
+                                {
+                                    trsrList.Add(treasure.Key, treasure.Value);
+                                }
+
                             }
                                 Kh2.SystemData.Trsr.Write(stream.SetPosition(0), trsrList.Values);
                             break;
@@ -320,6 +328,10 @@ namespace OpenKh.Patcher
                                     {
                                         itemList.Items[itemList.Items.IndexOf(itemToUpdate)] = item;
                                     }
+                                    else
+                                    {
+                                        itemList.Items.Add(item);
+                                    }
                                 }
                             }
                             if (moddedItem.Stats != null)
@@ -330,6 +342,10 @@ namespace OpenKh.Patcher
                                     if (itemToUpdate != null)
                                     {
                                         itemList.Stats[itemList.Stats.IndexOf(itemToUpdate)] = item;
+                                    }
+                                    else
+                                    {
+                                        itemList.Stats.Add(item);
                                     }
                                 }
                             }
@@ -382,7 +398,14 @@ namespace OpenKh.Patcher
                             var moddedBonus = deserializer.Deserialize<Dictionary<string, Kh2.Battle.Bons>>(sourceText);
                                 foreach (var bonus in moddedBonus)
                                 {
-                                    bonusList[bonus.Key] = bonus.Value;
+                                    if (bonusList.ContainsKey(bonus.Key))
+                                    {
+                                        bonusList[bonus.Key] = bonus.Value;
+                                    }
+                                    else
+                                    {
+                                        bonusList.Add(bonus.Key, bonus.Value);
+                                    } 
                                 }
                             Kh2.Battle.Bons.Write(stream.SetPosition(0), bonusList.Values);
                             break;
@@ -392,7 +415,14 @@ namespace OpenKh.Patcher
                             var moddedObjEntry = deserializer.Deserialize<Dictionary<uint, Kh2.Objentry>>(sourceText);
                             foreach (var objEntry in moddedObjEntry)
                             {
-                                objEntryList[objEntry.Key] = objEntry.Value;
+                                if (objEntryList.ContainsKey(objEntry.Key))
+                                {
+                                    objEntryList[objEntry.Key] = objEntry.Value;
+                                }
+                                else
+                                {
+                                    objEntryList.Add(objEntry.Key, objEntry.Value);
+                                }
                             }
                             Kh2.Objentry.Write(stream.SetPosition(0), objEntryList.Values);
                             break;

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -311,25 +311,25 @@ namespace OpenKh.Patcher
                         case "item":
                             var itemList = Kh2.SystemData.Item.Read(stream);
                             var moddedItem = deserializer.Deserialize<Kh2.SystemData.Item>(sourceText);
-                            if (moddedItem.Items1 != null)
+                            if (moddedItem.Items != null)
                             {
-                                foreach (var item in moddedItem.Items1)
+                                foreach (var item in moddedItem.Items)
                                 {
-                                    var itemToUpdate = itemList.Items1.FirstOrDefault(x => x.Id == item.Id);
+                                    var itemToUpdate = itemList.Items.FirstOrDefault(x => x.Id == item.Id);
                                     if (itemToUpdate != null)
                                     {
-                                        itemList.Items1[itemList.Items1.IndexOf(itemToUpdate)] = item;
+                                        itemList.Items[itemList.Items.IndexOf(itemToUpdate)] = item;
                                     }
                                 }
                             }
-                            if (moddedItem.Items2 != null)
+                            if (moddedItem.Stats != null)
                             {
-                                foreach (var item in moddedItem.Items2)
+                                foreach (var item in moddedItem.Stats)
                                 {
-                                    var itemToUpdate = itemList.Items2.FirstOrDefault(x => x.Id == item.Id);
+                                    var itemToUpdate = itemList.Stats.FirstOrDefault(x => x.Id == item.Id);
                                     if (itemToUpdate != null)
                                     {
-                                        itemList.Items2[itemList.Items2.IndexOf(itemToUpdate)] = item;
+                                        itemList.Stats[itemList.Stats.IndexOf(itemToUpdate)] = item;
                                     }
                                 }
                             }

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -123,8 +123,8 @@ namespace OpenKh.Patcher
                 case "areadatascript":
                     PatchAreaDataScript(context, assetFile.Source, stream);
                     break;
-                case "listreplace":
-                    PatchListReplace(context, assetFile.Source, stream);
+                case "listpatch":
+                    PatchList(context, assetFile.Source, stream);
                     break;
                 default:
                     Log.Warn($"Method '{assetFile.Method}' not recognized for '{assetFile.Name}'. Falling back to 'copy'");
@@ -291,7 +291,7 @@ namespace OpenKh.Patcher
 
         private static readonly IDeserializer deserializer = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
             
-        private static void PatchListReplace(Context context, List<AssetFile> sources, Stream stream)
+        private static void PatchList(Context context, List<AssetFile> sources, Stream stream)
         {
             foreach (var source in sources)
             {

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -311,22 +311,37 @@ namespace OpenKh.Patcher
                         case "item":
                             var itemList = Kh2.SystemData.Item.Read(stream);
                             var moddedItem = deserializer.Deserialize<Kh2.SystemData.Item>(sourceText);
-                            itemList = moddedItem;
+                             foreach (var item in moddedItem.Items1)
+                             {
+                                var itemToUpdate = itemList.Items1.FirstOrDefault(x => x.Id == item.Id);
+                                if (itemToUpdate != null)
+                                {
+                                    itemList.Items1[itemList.Items1.IndexOf(itemToUpdate)] = item;
+                                }
+                             }
+                             foreach (var item in moddedItem.Items2)
+                             {
+                                var itemToUpdate = itemList.Items2.FirstOrDefault(x => x.Id == item.Id);
+                                if (itemToUpdate != null)
+                                {
+                                    itemList.Items2[itemList.Items2.IndexOf(itemToUpdate)] = item;
+                                }
+                             }
                             itemList.Write(stream.SetPosition(0));
                             break;
 
                         case "fmlv":
                             var formRaw = Kh2.Battle.Fmlv.Read(stream).ToList();
-                            var formList = new Dictionary<Kh2.Battle.Fmlv.FormFm, List<Kh2.Battle.Fmlv.Level>>();
+                            var formList = new Dictionary<Kh2.Battle.Fmlv.FormFm, List<Kh2.Battle.Fmlv>>();
                             foreach (var form in formRaw)
                             {
-                                if (!formList.ContainsKey(form.FormFm))
+                                if (!formList.ContainsKey(form.FinalMixForm))
                                 {
-                                    formList.Add(form.FormFm, new List<Kh2.Battle.Fmlv.Level>());
+                                    formList.Add(form.FinalMixForm, new List<Kh2.Battle.Fmlv>());
                                 }
-                                formList[form.FormFm].Add(form);
+                                formList[form.FinalMixForm].Add(form);
                             }
-                            var moddedForms = deserializer.Deserialize<Dictionary<Kh2.Battle.Fmlv.FormFm, List<Kh2.Battle.Fmlv.Level>>>(sourceText);
+                            var moddedForms = deserializer.Deserialize<Dictionary<Kh2.Battle.Fmlv.FormFm, List<Kh2.Battle.Fmlv>>>(sourceText);
                             foreach (var form in moddedForms)
                             {
                                 foreach (var level in form.Value)

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -352,9 +352,9 @@ namespace OpenKh.Patcher
                                 {
                                     foreach (var level in form.Value)
                                     {
-                                        formList[level.FormFm][level.FormLevel - 1].Ability = level.Ability;
-                                        formList[level.FormFm][level.FormLevel - 1].Exp = level.Exp;
-                                        formList[level.FormFm][level.FormLevel - 1].LevelGrowthAbility = level.LevelGrowthAbility;
+                                        formList[form.Key][level.FormLevel - 1].Ability = level.Ability;
+                                        formList[form.Key][level.FormLevel - 1].Exp = level.Experience;
+                                        formList[form.Key][level.FormLevel - 1].LevelGrowthAbility = level.GrowthAbilityLevel;
                                         
                                     }
 

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -45,7 +45,7 @@ namespace OpenKh.Patcher
                 {
                     var originalFile = GetOriginalAssetPath(fileName);
                     if (File.Exists(originalFile))
-                        File.Copy(originalFile, dstFile);
+                        File.Copy(originalFile, dstFile,true);
                 }
             }
         }
@@ -302,54 +302,54 @@ namespace OpenKh.Patcher
                     switch (source.Type)
                     {
                         case "trsr":
-                            var TrsrList = Kh2.SystemData.Trsr.Read(stream).ToDictionary(x => x.Id, x => x);
+                            var trsrList = Kh2.SystemData.Trsr.Read(stream).ToDictionary(x => x.Id, x => x);
                             var moddedTrsr = deserializer.Deserialize<Dictionary<int, Kh2.SystemData.Trsr>>(sourceText);
                             foreach (KeyValuePair<int, Kh2.SystemData.Trsr> treasure in moddedTrsr)
                             {
-                                TrsrList[treasure.Value.Id].ItemId = treasure.Value.ItemId;
+                                trsrList[treasure.Value.Id].ItemId = treasure.Value.ItemId;
                             }
-                                Kh2.SystemData.Trsr.Write(stream.SetPosition(0), TrsrList.Values);
+                                Kh2.SystemData.Trsr.Write(stream.SetPosition(0), trsrList.Values);
                             break;
 
                         case "item":
-                            var ItemList = Kh2.SystemData.Item.Read(stream);
+                            var itemList = Kh2.SystemData.Item.Read(stream);
                             var moddedItem = deserializer.Deserialize<Kh2.SystemData.Item>(sourceText);
-                            ItemList = moddedItem;
-                            ItemList.Write(stream.SetPosition(0));
+                            itemList = moddedItem;
+                            itemList.Write(stream.SetPosition(0));
                             break;
 
                         case "fmlv":
-                            var FormList = Kh2.Battle.Fmlv.Read(stream).ToDictionary(x => String.Concat(x.FormFm, x.FormLevel), x => x);
+                            var formList = Kh2.Battle.Fmlv.Read(stream).ToDictionary(x => String.Concat(x.FormFm, x.FormLevel), x => x);
                             var moddedForms = deserializer.Deserialize<Dictionary<string, Kh2.Battle.Fmlv.Level>>(sourceText);
                             foreach (KeyValuePair<string, Kh2.Battle.Fmlv.Level> form in moddedForms)
                             {
-                                FormList[form.Key].Ability = form.Value.Ability;
-                                FormList[form.Key].LevelGrowthAbility = form.Value.LevelGrowthAbility;
-                                FormList[form.Key].Exp = form.Value.Exp;
+                                formList[form.Key].Ability = form.Value.Ability;
+                                formList[form.Key].LevelGrowthAbility = form.Value.LevelGrowthAbility;
+                                formList[form.Key].Exp = form.Value.Exp;
                             }
-                            Kh2.Battle.Fmlv.Write(stream.SetPosition(0), FormList.Values);
+                            Kh2.Battle.Fmlv.Write(stream.SetPosition(0), formList.Values);
                             break;
 
                         case "lvup":
-                            var LevelList = Kh2.Battle.Lvup.Read(stream);
+                            var levelList = Kh2.Battle.Lvup.Read(stream);
                             var moddedLevels = deserializer.Deserialize<Kh2.Battle.Lvup>(sourceText);
                             int i = 0;
                             foreach (Kh2.Battle.Lvup.PlayableCharacter character in moddedLevels.Characters)
                             {
-                                LevelList.Characters[i].Levels = character.Levels;
+                                levelList.Characters[i].Levels = character.Levels;
                                 i++;
                             }
-                            LevelList.Write(stream.SetPosition(0));
+                            levelList.Write(stream.SetPosition(0));
                             break;
 
                         case "bons":
-                            var BonusList = Kh2.Battle.Bons.Read(stream).ToDictionary(x => String.Concat(x.RewardId, characterMap.FirstOrDefault(y => y.Value == x.CharacterId).Key), x => x);
+                            var bonusList = Kh2.Battle.Bons.Read(stream).ToDictionary(x => String.Concat(x.RewardId, characterMap.FirstOrDefault(y => y.Value == x.CharacterId).Key), x => x);
                             var moddedBonus = deserializer.Deserialize<Dictionary<string, Kh2.Battle.Bons>>(sourceText);
                             foreach (KeyValuePair<string, Kh2.Battle.Bons> bonus in moddedBonus)
                             {
-                                BonusList[bonus.Key] = bonus.Value;
+                                bonusList[bonus.Key] = bonus.Value;
                             }
-                            Kh2.Battle.Bons.Write(stream.SetPosition(0), BonusList.Values);
+                            Kh2.Battle.Bons.Write(stream.SetPosition(0), bonusList.Values);
                             break;
 
                         default:

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -301,7 +301,7 @@ namespace OpenKh.Patcher
                         case "trsr":
                             var trsrList = Kh2.SystemData.Trsr.Read(stream).ToDictionary(x => x.Id, x => x);
                             var moddedTrsr = deserializer.Deserialize<Dictionary<int, Kh2.SystemData.Trsr>>(sourceText);
-                            foreach (KeyValuePair<int, Kh2.SystemData.Trsr> treasure in moddedTrsr)
+                            foreach (var treasure in moddedTrsr)
                             {
                                 trsrList[treasure.Value.Id].ItemId = treasure.Value.ItemId;
                             }
@@ -318,7 +318,7 @@ namespace OpenKh.Patcher
                         case "fmlv":
                             var formList = Kh2.Battle.Fmlv.Read(stream).ToDictionary(x => String.Concat(x.FormFm, x.FormLevel), x => x);
                             var moddedForms = deserializer.Deserialize<Dictionary<string, Kh2.Battle.Fmlv.Level>>(sourceText);
-                            foreach (KeyValuePair<string, Kh2.Battle.Fmlv.Level> form in moddedForms)
+                            foreach (var form in moddedForms)
                             {
                                 formList[form.Key].Ability = form.Value.Ability;
                                 formList[form.Key].LevelGrowthAbility = form.Value.LevelGrowthAbility;
@@ -331,7 +331,7 @@ namespace OpenKh.Patcher
                             var levelList = Kh2.Battle.Lvup.Read(stream);
                             var moddedLevels = deserializer.Deserialize<Kh2.Battle.Lvup>(sourceText);
                             int i = 0;
-                            foreach (Kh2.Battle.Lvup.PlayableCharacter character in moddedLevels.Characters)
+                            foreach (var character in moddedLevels.Characters)
                             {
                                 levelList.Characters[i].Levels = character.Levels;
                                 i++;
@@ -342,7 +342,7 @@ namespace OpenKh.Patcher
                         case "bons":
                             var bonusList = Kh2.Battle.Bons.Read(stream).ToDictionary(x => String.Concat(x.RewardId, characterMap.FirstOrDefault(y => y.Value == x.CharacterId).Key), x => x);
                             var moddedBonus = deserializer.Deserialize<Dictionary<string, Kh2.Battle.Bons>>(sourceText);
-                            foreach (KeyValuePair<string, Kh2.Battle.Bons> bonus in moddedBonus)
+                            foreach (var bonus in moddedBonus)
                             {
                                 bonusList[bonus.Key] = bonus.Value;
                             }

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -515,6 +515,371 @@ namespace OpenKh.Tests.Patcher
         }
 
         [Fact]
+        public void ListReplaceTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata
+            {
+                Assets = new List<AssetFile>
+                { new AssetFile
+                {
+                    Name = "fmlv.bin",
+                    Method = "binarc",
+                    Source = new List<AssetFile>
+                    {
+                        new AssetFile
+                        {
+                            Name = "fmlv",
+                            Method = "listreplace",
+                            Type = "List",
+                            Source = new List<AssetFile>
+                            {
+                                new AssetFile
+                                {
+                                    Name = "FmlvList.yml",
+                                    Type = "fmlv"
+                                }
+                            }
+                        }
+                    }
+                },
+                new AssetFile
+                {
+                    Name = "lvup.bin",
+                    Method = "binarc",
+                    Source = new List<AssetFile>
+                    {
+                        new AssetFile
+                        {
+                            Name = "lvup",
+                            Method = "listreplace",
+                            Type = "List",
+                            Source = new List<AssetFile>
+                            {
+                                new AssetFile
+                                {
+                                    Name = "LvupList.yml",
+                                    Type = "lvup"
+                                }
+                            }
+                        }
+                    }
+                },
+                new AssetFile
+                {
+                    Name = "bons.bin",
+                    Method = "binarc",
+                    Source = new List<AssetFile>
+                    {
+                        new AssetFile
+                        {
+                            Name = "bons",
+                            Method = "listreplace",
+                            Type = "List",
+                            Source = new List<AssetFile>
+                            {
+                                new AssetFile
+                                {
+                                    Name = "BonsList.yml",
+                                    Type = "bons"
+                                }
+                            }
+                        }
+                    }
+                },
+                new AssetFile
+                {
+                    Name = "trsr.bin",
+                    Method = "binarc",
+                    Source = new List<AssetFile>
+                    {
+                        new AssetFile
+                        {
+                            Name = "trsr",
+                            Method = "listreplace",
+                            Type = "List",
+                            Source = new List<AssetFile>
+                            {
+                                new AssetFile
+                                {
+                                    Name = "TrsrList.yml",
+                                    Type = "trsr"
+                                }
+                            }
+                        }
+                    }
+                },
+                new AssetFile
+                {
+                    Name = "item.bin",
+                    Method = "binarc",
+                    Source = new List<AssetFile>
+                    {
+                        new AssetFile
+                        {
+                            Name = "item",
+                            Method = "listreplace",
+                            Type = "List",
+                            Source = new List<AssetFile>
+                            {
+                                new AssetFile
+                                {
+                                    Name = "ItemList.yml",
+                                    Type = "item"
+                                }
+                            }
+                        }
+                    }
+                }
+                }
+            };
+
+
+            #region fmlvPatch
+
+            File.Create(Path.Combine(AssetsInputDir, "fmlv.bin")).Using(stream =>
+            {
+                var fmlvStream = new List<Kh2.Battle.Fmlv>{
+                    new Kh2.Battle.Fmlv {
+                        Unk0 = 17,
+                        AbilityLevel = 0,
+                        Ability = 1,
+                        Exp = 70,
+                        FormId = 1,
+                        FormLevel = 1,
+                        VanillaForm = Kh2.Battle.Fmlv.FormVanilla.Valor,
+                        FinalMixForm = Kh2.Battle.Fmlv.FormFm.Valor
+                    }
+                };
+                Kh2.Battle.Fmlv.Write(stream,fmlvStream);
+            });
+
+            var testFmlv = new Kh2.Battle.Fmlv
+            {
+                Unk0 = 17,
+                AbilityLevel = 1,
+                Ability = 17,
+                Exp = 1,
+                FormId = 1,
+                FormLevel = 1,
+                VanillaForm = Kh2.Battle.Fmlv.FormVanilla.Valor,
+                FinalMixForm = Kh2.Battle.Fmlv.FormFm.Valor
+            };
+
+            var fmlvDict = new Dictionary<Kh2.Battle.Fmlv.FormFm, List<Kh2.Battle.Fmlv>>();
+            fmlvDict.Add(Kh2.Battle.Fmlv.FormFm.Valor, new List<Kh2.Battle.Fmlv>() { testFmlv });
+
+            File.WriteAllText(Path.Combine(ModInputDir, "FmlvList.yml"), serializer.Serialize(fmlvDict));
+
+            #endregion
+
+            #region lvupPatch
+
+            File.Create(Path.Combine(AssetsInputDir, "lvup.bin")).Using(stream =>
+            {
+                var fmlvStream = new Kh2.Battle.Lvup { 
+                    Characters = new List<Kh2.Battle.Lvup.PlayableCharacter>
+                    {
+                        new Kh2.Battle.Lvup.PlayableCharacter
+                        {
+                            NumLevels = 99,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level
+                                {
+                                    Exp = 1000,
+                                    Ap = 3,
+                                    Strength = 4,
+                                    Magic = 5,
+                                    Defense = 6,
+                                    SwordAbility = 100,
+                                    ShieldAbility = 101,
+                                    StaffAbility = 102
+                                }
+                            }
+                        }
+                    }
+                };
+                fmlvStream.Write(stream);
+            });
+
+            var soraLevel0 = new Kh2.Battle.Lvup.PlayableCharacter.Level
+            {
+                Exp = 100,
+                Ap = 99,
+                Strength = 40,
+                Magic = 50,
+                Defense = 60,
+                SwordAbility = 152,
+                ShieldAbility = 153,
+                StaffAbility = 154
+            };
+
+            var testLvup = new Kh2.Battle.Lvup
+            {
+                Characters = new List<Kh2.Battle.Lvup.PlayableCharacter>
+                {
+                    new Kh2.Battle.Lvup.PlayableCharacter
+                    {
+                        NumLevels = 99,
+                        Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>
+                        {
+                            soraLevel0
+                        }
+                    }
+                }
+            };
+
+
+            File.WriteAllText(Path.Combine(ModInputDir, "LvupList.yml"), serializer.Serialize(testLvup));
+
+            #endregion
+
+            #region bonsPatch
+
+            File.Create(Path.Combine(AssetsInputDir, "bons.bin")).Using(stream =>
+            {
+                var bonsStream = new Kh2.Battle.Bons
+                {
+                    CharacterId = 0,
+                    RewardId = 1,
+                    BonusItem1 = 10,
+                    BonusItem2 = 20
+                };
+                Kh2.Battle.Bons.Write(stream, new List<Kh2.Battle.Bons> { bonsStream });
+            });
+
+            var testBons = new List<Kh2.Battle.Bons>
+            {
+                new Kh2.Battle.Bons
+                {
+                    CharacterId = 0,
+                    RewardId = 1,
+                    BonusItem1 = 100,
+                    BonusItem2 = 200
+                }
+            };
+
+            File.WriteAllText(Path.Combine(ModInputDir, "BonsList.yml"), serializer.Serialize(testBons));
+
+            #endregion
+
+            #region trsrPatch
+            File.Create(Path.Combine(AssetsInputDir, "trsr.bin")).Using(stream =>
+            {
+                var trsrStream = new Kh2.SystemData.Trsr
+                {
+                    Id = 120,
+                    ItemId = 10
+                };
+                Kh2.SystemData.Trsr.Write(stream, new List<Kh2.SystemData.Trsr>
+                {
+                    trsrStream
+                });
+            });
+
+            var testTrsr = new List<Kh2.SystemData.Trsr>
+            {
+                new Kh2.SystemData.Trsr
+                {
+                    Id = 120,
+                    ItemId = 100
+                }
+            };
+
+            File.WriteAllText(Path.Combine(ModInputDir, "TrsrList.yml"), serializer.Serialize(testTrsr));
+            #endregion
+
+            #region itemPatch
+            File.Create(Path.Combine(AssetsInputDir, "item.bin")).Using(stream =>
+            {
+                var itemStream = new Kh2.SystemData.Item
+                {
+                    Items1 = new List<Kh2.SystemData.Item.Entry>
+                    {
+                        new Kh2.SystemData.Item.Entry
+                        {
+                            Id = 130,
+                            ShopSell = 10
+                        }
+                    },
+                    Items2 = new List<Kh2.SystemData.Item.Stat>
+                    {
+                        new Kh2.SystemData.Item.Stat
+                        {
+                            Id = 140,
+                            Ability = 10
+                        }
+                    }
+                };
+                itemStream.Write(stream);
+            });
+
+            var testItem = new Kh2.SystemData.Item
+            {
+                Items1 = new List<Kh2.SystemData.Item.Entry>
+                {
+                    new Kh2.SystemData.Item.Entry
+                    {
+                        Id = 130,
+                        ShopSell = 100
+                    }
+                },
+                Items2 = new List<Kh2.SystemData.Item.Stat>
+                {
+                    new Kh2.SystemData.Item.Stat
+                    {
+                        Id = 140,
+                        Ability = 100
+                    }
+                }
+            };
+
+            File.WriteAllText(Path.Combine(ModInputDir, "ItemList.yml"), serializer.Serialize(testItem));
+            
+
+
+            #endregion
+
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
+
+            AssertFileExists(ModOutputDir, "fmlv.bin");
+            AssertFileExists(ModOutputDir, "lvup.bin");
+            AssertFileExists(ModOutputDir, "bons.bin");
+            AssertFileExists(ModOutputDir, "trsr.bin");
+            AssertFileExists(ModOutputDir, "item.bin");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "fmlv.bin")).Using(stream =>
+            {
+                var fmlv = Kh2.Battle.Fmlv.Read(stream);
+                Assert.True(fmlv[0] == testFmlv);
+            });
+            File.OpenRead(Path.Combine(ModOutputDir, "lvup.bin")).Using(stream =>
+            {
+                var lvup = Kh2.Battle.Lvup.Read(stream);
+                Assert.True(lvup.Characters[0].Levels[0] == soraLevel0);
+            });
+            File.OpenRead(Path.Combine(ModOutputDir, "bons.bin")).Using(stream =>
+            {
+                var bons = Kh2.Battle.Bons.Read(stream);
+                Assert.True(bons[0] == testBons[0]);
+            });
+            File.OpenRead(Path.Combine(ModOutputDir, "trsr.bin")).Using(stream =>
+            {
+                var trsr = Kh2.SystemData.Trsr.Read(stream);
+                Assert.True(trsr[0] == testTrsr[0]);
+            });
+            File.OpenRead(Path.Combine(ModOutputDir, "item.bin")).Using(stream =>
+            {
+                var item = Kh2.SystemData.Item.Read(stream);
+                Assert.True(item.Items1[0] == testItem.Items1[0]);
+                Assert.True(item.Items2[0] == testItem.Items2[0]);
+            });
+
+        }
+
+        [Fact]
         public void ProcessMultipleTest()
         {
             var patcher = new PatcherProcessor();

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -585,7 +585,7 @@ namespace OpenKh.Tests.Patcher
              {
                  var binarc = Bar.Read(stream);
                  var trsrStream = Kh2.SystemData.Trsr.Read(binarc[0].Stream);
-                 Assert.True(trsrStream[0].ItemId == 200);
+                 Assert.Equal(200, trsrStream[0].ItemId);
              });
 
         }
@@ -681,8 +681,8 @@ namespace OpenKh.Tests.Patcher
             {
                 var binarc = Bar.Read(stream);
                 var itemStream = Kh2.SystemData.Item.Read(binarc[0].Stream);
-                Assert.True(itemStream.Items[0].ShopBuy == 200);
-                Assert.True(itemStream.Stats[0].Ability == 150);
+                Assert.Equal(200, itemStream.Items[0].ShopBuy);
+                Assert.Equal(150, itemStream.Stats[0].Ability);
             });
 
         }
@@ -877,7 +877,7 @@ namespace OpenKh.Tests.Patcher
             {
                 var binarc = Bar.Read(stream);
                 var bonsStream = Kh2.Battle.Bons.Read(binarc[0].Stream);
-                Assert.True(bonsStream[0].BonusItem1 == 200);
+                Assert.Equal(200, bonsStream[0].BonusItem1);
             });
 
         }
@@ -1099,7 +1099,7 @@ namespace OpenKh.Tests.Patcher
             {
                 var binarc = Bar.Read(stream);
                 var lvupStream = Kh2.Battle.Lvup.Read(binarc[0].Stream);
-                Assert.True(lvupStream.Characters[0].Levels[0].Exp == 500);
+                Assert.Equal(500, lvupStream.Characters[0].Levels[0].Exp);
             });
 
         }
@@ -1161,8 +1161,8 @@ namespace OpenKh.Tests.Patcher
             File.OpenRead(Path.Combine(ModOutputDir, "00objentry.bin")).Using(stream =>
             {
                 var objStream = Kh2.Objentry.Read(stream);
-                Assert.True(objStream[0].ModelName == "M_EX100");
-                Assert.True(objStream[0].AnimationName == "M_EX100.mset");
+                Assert.Equal("M_EX100", objStream[0].ModelName);
+                Assert.Equal("M_EX100.mset", objStream[0].AnimationName);
             });
 
         }

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -845,6 +845,12 @@ namespace OpenKh.Tests.Patcher
                         CharacterId = 1,
                         RewardId = 15,
                         BonusItem1 = 10
+                    },
+                    new Kh2.Battle.Bons
+                    {
+                        CharacterId = 2,
+                        RewardId = 15,
+                        BonusItem1 = 5
                     }
                     };
                 using var bonsStream = new MemoryStream();
@@ -862,10 +868,9 @@ namespace OpenKh.Tests.Patcher
             File.Create(Path.Combine(ModInputDir, "BonsList.yml")).Using(stream =>
             {
                 var writer = new StreamWriter(stream);
-                writer.WriteLine("15Sora:");
-                writer.WriteLine("  RewardId: 15");
-                writer.WriteLine("  CharacterId: 1");
-                writer.WriteLine("  BonusItem1: 200");
+                writer.WriteLine("15:");
+                writer.WriteLine("  Sora:");
+                writer.WriteLine("    BonusItem1: 200");
                 writer.Flush();
             });
 
@@ -878,6 +883,7 @@ namespace OpenKh.Tests.Patcher
                 var binarc = Bar.Read(stream);
                 var bonsStream = Kh2.Battle.Bons.Read(binarc[0].Stream);
                 Assert.Equal(200, bonsStream[0].BonusItem1);
+                Assert.Equal(5, bonsStream[1].BonusItem1);
             });
 
         }

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -1014,13 +1014,13 @@ namespace OpenKh.Tests.Patcher
                 new AssetFile
                 {
                     Name = "objentry.bin",
-                    Method = "binarc",
+                    Method = "listreplace",
                     Source = new List<AssetFile>
                     {
                         new AssetFile
                         {
                             Name = "ObjEntryList.yml",
-                            Type = "obj"
+                            Type = "objentry"
                         }
                     }
                 },

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -515,7 +515,7 @@ namespace OpenKh.Tests.Patcher
         }
 
         [Fact]
-        public void ListReplaceTrsrTest()
+        public void ListPatchTrsrTest()
         {
             var patcher = new PatcherProcessor();
             var serializer = new Serializer();
@@ -591,7 +591,7 @@ namespace OpenKh.Tests.Patcher
         }
 
         [Fact]
-        public void ListReplaceItemTest()
+        public void ListPatchItemTest()
         {
             var patcher = new PatcherProcessor();
             var serializer = new Serializer();
@@ -688,7 +688,7 @@ namespace OpenKh.Tests.Patcher
         }
 
         [Fact]
-        public void ListReplaceFmlvTest()
+        public void ListPatchFmlvTest()
         {
             var patcher = new PatcherProcessor();
             var serializer = new Serializer();
@@ -803,7 +803,7 @@ namespace OpenKh.Tests.Patcher
         }
 
         [Fact]
-        public void ListReplaceBonsTest()
+        public void ListPatchBonsTest()
         {
             var patcher = new PatcherProcessor();
             var serializer = new Serializer();
@@ -889,7 +889,7 @@ namespace OpenKh.Tests.Patcher
         }
 
         [Fact]
-        public void ListReplaceLvupTest()
+        public void ListPatchLvupTest()
         {
             var patcher = new PatcherProcessor();
             var serializer = new Serializer();
@@ -1111,7 +1111,7 @@ namespace OpenKh.Tests.Patcher
         }
 
         [Fact]
-        public void ListReplaceObjEntryTest()
+        public void ListPatchObjEntryTest()
         {
             var patcher = new PatcherProcessor();
             var serializer = new Serializer();

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -730,12 +730,25 @@ namespace OpenKh.Tests.Patcher
                     {
                         FormId = 1,
                         FormLevel = 1,
-                        FormFm = Kh2.Battle.Fmlv.FormFm.Valor,
-                        FormVanilla = Kh2.Battle.Fmlv.FormVanilla.Valor,
-                        Exp= 100,
+                        Exp = 100,
                         Ability = 200
-                    }
-                    };
+                    },
+                    new Kh2.Battle.Fmlv.Level
+                    {
+                        FormId = 1,
+                        FormLevel = 2,
+                        Exp = 100,
+                        Ability = 200
+                    },
+                    new Kh2.Battle.Fmlv.Level
+                    {
+                        FormId = 2,
+                        FormLevel = 1,
+                        Exp = 100,
+                        Ability = 200
+                    },
+                };
+
                 using var fmlvStream = new MemoryStream();
                 Kh2.Battle.Fmlv.Write(fmlvStream, fmlvEntry);
                 Bar.Write(stream, new Bar() {
@@ -758,9 +771,9 @@ namespace OpenKh.Tests.Patcher
                     {
                         new FmlvDTO
                         {
-                        FormLevel = 1,
-                        Experience = 5,
-                        Ability = 127
+                            FormLevel = 1,
+                            Experience = 5,
+                            Ability = 127
                         }
                     }
                 });
@@ -774,11 +787,20 @@ namespace OpenKh.Tests.Patcher
             File.OpenRead(Path.Combine(ModOutputDir, "00battle.bar")).Using(stream =>
             {
                 var binarc = Bar.Read(stream);
-                var fmlvStream = Kh2.Battle.Fmlv.Read(binarc[0].Stream);
-                Assert.True(fmlvStream[0].Exp == 5);
-                Assert.True(fmlvStream[0].Ability == 127);
-            });
+                var fmlv = Kh2.Battle.Fmlv.Read(binarc[0].Stream);
 
+                Assert.Equal(3, fmlv.Count);
+                Assert.Equal(1, fmlv[0].FormId);
+                Assert.Equal(1, fmlv[0].FormLevel);
+                Assert.Equal(5, fmlv[0].Exp);
+                Assert.Equal(127, fmlv[0].Ability);
+
+                Assert.Equal(1, fmlv[1].FormId);
+                Assert.Equal(2, fmlv[1].FormLevel);
+
+                Assert.Equal(2, fmlv[2].FormId);
+                Assert.Equal(1, fmlv[2].FormLevel);
+            });
         }
 
         [Fact]

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -631,7 +631,7 @@ namespace OpenKh.Tests.Patcher
                 {
                     new Kh2.SystemData.Item
                     {
-                        Items1 = new List<Kh2.SystemData.Item.Entry>()
+                        Items = new List<Kh2.SystemData.Item.Entry>()
                         {
                             new Kh2.SystemData.Item.Entry()
                             {
@@ -639,7 +639,7 @@ namespace OpenKh.Tests.Patcher
                                 ShopBuy = 10
                             }
                         },
-                        Items2 = new List<Kh2.SystemData.Item.Stat>()
+                        Stats = new List<Kh2.SystemData.Item.Stat>()
                         {
                             new Kh2.SystemData.Item.Stat()
                             {
@@ -665,10 +665,10 @@ namespace OpenKh.Tests.Patcher
             File.Create(Path.Combine(ModInputDir, "ItemList.yml")).Using(stream =>
             {
                 var writer = new StreamWriter(stream);
-                writer.WriteLine("Items1:");
+                writer.WriteLine("Items:");
                 writer.WriteLine("- Id: 1");
                 writer.WriteLine("  ShopBuy: 200");
-                writer.WriteLine("Items2:");
+                writer.WriteLine("Stats:");
                 writer.WriteLine("- Id: 10");
                 writer.WriteLine("  Ability: 150");
                 writer.Flush();
@@ -682,8 +682,8 @@ namespace OpenKh.Tests.Patcher
             {
                 var binarc = Bar.Read(stream);
                 var itemStream = Kh2.SystemData.Item.Read(binarc[0].Stream);
-                Assert.True(itemStream.Items1[0].ShopBuy == 200);
-                Assert.True(itemStream.Items2[0].Ability == 150);
+                Assert.True(itemStream.Items[0].ShopBuy == 200);
+                Assert.True(itemStream.Stats[0].Ability == 150);
             });
 
         }

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -515,7 +515,7 @@ namespace OpenKh.Tests.Patcher
         }
 
         [Fact]
-        public void ListReplaceTest()
+        public void ListReplaceFmlvTest()
         {
             var patcher = new PatcherProcessor();
             var serializer = new Serializer();
@@ -539,94 +539,6 @@ namespace OpenKh.Tests.Patcher
                                 {
                                     Name = "FmlvList.yml",
                                     Type = "fmlv"
-                                }
-                            }
-                        }
-                    }
-                },
-                new AssetFile
-                {
-                    Name = "lvup.bin",
-                    Method = "binarc",
-                    Source = new List<AssetFile>
-                    {
-                        new AssetFile
-                        {
-                            Name = "lvup",
-                            Method = "listreplace",
-                            Type = "List",
-                            Source = new List<AssetFile>
-                            {
-                                new AssetFile
-                                {
-                                    Name = "LvupList.yml",
-                                    Type = "lvup"
-                                }
-                            }
-                        }
-                    }
-                },
-                new AssetFile
-                {
-                    Name = "bons.bin",
-                    Method = "binarc",
-                    Source = new List<AssetFile>
-                    {
-                        new AssetFile
-                        {
-                            Name = "bons",
-                            Method = "listreplace",
-                            Type = "List",
-                            Source = new List<AssetFile>
-                            {
-                                new AssetFile
-                                {
-                                    Name = "BonsList.yml",
-                                    Type = "bons"
-                                }
-                            }
-                        }
-                    }
-                },
-                new AssetFile
-                {
-                    Name = "trsr.bin",
-                    Method = "binarc",
-                    Source = new List<AssetFile>
-                    {
-                        new AssetFile
-                        {
-                            Name = "trsr",
-                            Method = "listreplace",
-                            Type = "List",
-                            Source = new List<AssetFile>
-                            {
-                                new AssetFile
-                                {
-                                    Name = "TrsrList.yml",
-                                    Type = "trsr"
-                                }
-                            }
-                        }
-                    }
-                },
-                new AssetFile
-                {
-                    Name = "item.bin",
-                    Method = "binarc",
-                    Source = new List<AssetFile>
-                    {
-                        new AssetFile
-                        {
-                            Name = "item",
-                            Method = "listreplace",
-                            Type = "List",
-                            Source = new List<AssetFile>
-                            {
-                                new AssetFile
-                                {
-                                    Name = "ItemList.yml",
-                                    Type = "item"
                                 }
                             }
                         }
@@ -674,11 +586,57 @@ namespace OpenKh.Tests.Patcher
 
             #endregion
 
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
+
+            AssertFileExists(ModOutputDir, "fmlv.bin");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "fmlv.bin")).Using(stream =>
+            {
+                var fmlv = Kh2.Battle.Fmlv.Read(stream);
+                Assert.True(fmlv[0] == testFmlv);
+            });
+        }
+
+        [Fact]
+        public void ListReplaceLvupTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata
+            {
+                Assets = new List<AssetFile>
+                {
+                new AssetFile
+                {
+                    Name = "lvup.bin",
+                    Method = "binarc",
+                    Source = new List<AssetFile>
+                    {
+                        new AssetFile
+                        {
+                            Name = "lvup",
+                            Method = "listreplace",
+                            Type = "List",
+                            Source = new List<AssetFile>
+                            {
+                                new AssetFile
+                                {
+                                    Name = "LvupList.yml",
+                                    Type = "lvup"
+                                }
+                            }
+                        }
+                    }
+                }
+                }
+            };
+
             #region lvupPatch
 
             File.Create(Path.Combine(AssetsInputDir, "lvup.bin")).Using(stream =>
             {
-                var fmlvStream = new Kh2.Battle.Lvup { 
+                var fmlvStream = new Kh2.Battle.Lvup
+                {
                     Characters = new List<Kh2.Battle.Lvup.PlayableCharacter>
                     {
                         new Kh2.Battle.Lvup.PlayableCharacter
@@ -736,6 +694,51 @@ namespace OpenKh.Tests.Patcher
 
             #endregion
 
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
+
+            AssertFileExists(ModOutputDir, "lvup.bin");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "lvup.bin")).Using(stream =>
+            {
+                var lvup = Kh2.Battle.Lvup.Read(stream);
+                Assert.True(lvup.Characters[0].Levels[0] == soraLevel0);
+            });
+        }
+
+        [Fact]
+        public void ListReplaceBonsTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata
+            {
+                Assets = new List<AssetFile>
+                {
+                new AssetFile
+                {
+                    Name = "bons.bin",
+                    Method = "binarc",
+                    Source = new List<AssetFile>
+                    {
+                        new AssetFile
+                        {
+                            Name = "bons",
+                            Method = "listreplace",
+                            Type = "List",
+                            Source = new List<AssetFile>
+                            {
+                                new AssetFile
+                                {
+                                    Name = "BonsList.yml",
+                                    Type = "bons"
+                                }
+                            }
+                        }
+                    }
+                },
+                }
+            };
+
             #region bonsPatch
 
             File.Create(Path.Combine(AssetsInputDir, "bons.bin")).Using(stream =>
@@ -765,6 +768,51 @@ namespace OpenKh.Tests.Patcher
 
             #endregion
 
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
+
+            AssertFileExists(ModOutputDir, "bons.bin");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "bons.bin")).Using(stream =>
+            {
+                var bons = Kh2.Battle.Bons.Read(stream);
+                Assert.True(bons[0] == testBons[0]);
+            });
+        }
+
+        [Fact]
+        public void ListReplaceTrsrTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata
+            {
+                Assets = new List<AssetFile>
+                {
+                new AssetFile
+                {
+                    Name = "trsr.bin",
+                    Method = "binarc",
+                    Source = new List<AssetFile>
+                    {
+                        new AssetFile
+                        {
+                            Name = "trsr",
+                            Method = "listreplace",
+                            Type = "List",
+                            Source = new List<AssetFile>
+                            {
+                                new AssetFile
+                                {
+                                    Name = "TrsrList.yml",
+                                    Type = "trsr"
+                                }
+                            }
+                        }
+                    }
+                }
+                }
+            };
+
             #region trsrPatch
             File.Create(Path.Combine(AssetsInputDir, "trsr.bin")).Using(stream =>
             {
@@ -790,6 +838,51 @@ namespace OpenKh.Tests.Patcher
 
             File.WriteAllText(Path.Combine(ModInputDir, "TrsrList.yml"), serializer.Serialize(testTrsr));
             #endregion
+
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
+
+            AssertFileExists(ModOutputDir, "trsr.bin");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "trsr.bin")).Using(stream =>
+            {
+                var trsr = Kh2.SystemData.Trsr.Read(stream);
+                Assert.True(trsr[0] == testTrsr[0]);
+            });
+        }
+
+        [Fact]
+        public void ListReplaceItemTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata
+            {
+                Assets = new List<AssetFile>
+                { 
+                new AssetFile
+                {
+                    Name = "item.bin",
+                    Method = "binarc",
+                    Source = new List<AssetFile>
+                    {
+                        new AssetFile
+                        {
+                            Name = "item",
+                            Method = "listreplace",
+                            Type = "List",
+                            Source = new List<AssetFile>
+                            {
+                                new AssetFile
+                                {
+                                    Name = "ItemList.yml",
+                                    Type = "item"
+                                }
+                            }
+                        }
+                    }
+                }
+                }
+            };
 
             #region itemPatch
             File.Create(Path.Combine(AssetsInputDir, "item.bin")).Using(stream =>
@@ -837,39 +930,15 @@ namespace OpenKh.Tests.Patcher
             };
 
             File.WriteAllText(Path.Combine(ModInputDir, "ItemList.yml"), serializer.Serialize(testItem));
-            
+
 
 
             #endregion
 
             patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
 
-            AssertFileExists(ModOutputDir, "fmlv.bin");
-            AssertFileExists(ModOutputDir, "lvup.bin");
-            AssertFileExists(ModOutputDir, "bons.bin");
-            AssertFileExists(ModOutputDir, "trsr.bin");
             AssertFileExists(ModOutputDir, "item.bin");
 
-            File.OpenRead(Path.Combine(ModOutputDir, "fmlv.bin")).Using(stream =>
-            {
-                var fmlv = Kh2.Battle.Fmlv.Read(stream);
-                Assert.True(fmlv[0] == testFmlv);
-            });
-            File.OpenRead(Path.Combine(ModOutputDir, "lvup.bin")).Using(stream =>
-            {
-                var lvup = Kh2.Battle.Lvup.Read(stream);
-                Assert.True(lvup.Characters[0].Levels[0] == soraLevel0);
-            });
-            File.OpenRead(Path.Combine(ModOutputDir, "bons.bin")).Using(stream =>
-            {
-                var bons = Kh2.Battle.Bons.Read(stream);
-                Assert.True(bons[0] == testBons[0]);
-            });
-            File.OpenRead(Path.Combine(ModOutputDir, "trsr.bin")).Using(stream =>
-            {
-                var trsr = Kh2.SystemData.Trsr.Read(stream);
-                Assert.True(trsr[0] == testTrsr[0]);
-            });
             File.OpenRead(Path.Combine(ModOutputDir, "item.bin")).Using(stream =>
             {
                 var item = Kh2.SystemData.Item.Read(stream);

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -531,7 +531,7 @@ namespace OpenKh.Tests.Patcher
                             new AssetFile()
                             {
                                 Name = "trsr",
-                                Method = "listreplace",
+                                Method = "listpatch",
                                 Type = "List",
                                 Source = new List<AssetFile>()
                                 {
@@ -608,7 +608,7 @@ namespace OpenKh.Tests.Patcher
                             new AssetFile()
                             {
                                 Name = "item",
-                                Method = "listreplace",
+                                Method = "listpatch",
                                 Type = "List",
                                 Source = new List<AssetFile>()
                                 {
@@ -705,7 +705,7 @@ namespace OpenKh.Tests.Patcher
                             new AssetFile()
                             {
                                 Name = "fmlv",
-                                Method = "listreplace",
+                                Method = "listpatch",
                                 Type = "List",
                                 Source = new List<AssetFile>()
                                 {
@@ -820,7 +820,7 @@ namespace OpenKh.Tests.Patcher
                             new AssetFile()
                             {
                                 Name = "bons",
-                                Method = "listreplace",
+                                Method = "listpatch",
                                 Type = "List",
                                 Source = new List<AssetFile>()
                                 {
@@ -906,7 +906,7 @@ namespace OpenKh.Tests.Patcher
                             new AssetFile()
                             {
                                 Name = "lvup",
-                                Method = "listreplace",
+                                Method = "listpatch",
                                 Type = "List",
                                 Source = new List<AssetFile>()
                                 {
@@ -1122,7 +1122,7 @@ namespace OpenKh.Tests.Patcher
                     new AssetFile()
                     {
                         Name = "00objentry.bin",
-                        Method = "listreplace",
+                        Method = "listpatch",
                         Type = "List",
                         Source = new List<AssetFile>()
                         {

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -573,7 +573,6 @@ namespace OpenKh.Tests.Patcher
             {
                 var writer = new StreamWriter(stream);
                 writer.WriteLine("1:");
-                writer.WriteLine("  Id: 1");
                 writer.WriteLine("  ItemId: 200");
                 writer.Flush();
             });

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -515,339 +515,80 @@ namespace OpenKh.Tests.Patcher
         }
 
         [Fact]
-        public void ListReplaceFmlvTest()
-        {
-            var patcher = new PatcherProcessor();
-            var serializer = new Serializer();
-            var patch = new Metadata
-            {
-                Assets = new List<AssetFile>
-                { new AssetFile
-                {
-                    Name = "fmlv.bin",
-                    Method = "binarc",
-                    Source = new List<AssetFile>
-                    {
-                        new AssetFile
-                        {
-                            Name = "fmlv",
-                            Method = "listreplace",
-                            Type = "List",
-                            Source = new List<AssetFile>
-                            {
-                                new AssetFile
-                                {
-                                    Name = "FmlvList.yml",
-                                    Type = "fmlv"
-                                }
-                            }
-                        }
-                    }
-                }
-                }
-            };
-
-
-            #region fmlvPatch
-
-            File.Create(Path.Combine(AssetsInputDir, "fmlv.bin")).Using(stream =>
-            {
-                var fmlvStream = new List<Kh2.Battle.Fmlv.Level>{
-                    new Kh2.Battle.Fmlv.Level {
-                        LevelGrowthAbility = 0,
-                        Ability = 1,
-                        Exp = 70,
-                        FormId = 1,
-                        FormLevel = 1,
-                        FormVanilla = Kh2.Battle.Fmlv.FormVanilla.Valor,
-                        FormFm = Kh2.Battle.Fmlv.FormFm.Valor
-                    }
-                };
-                Kh2.Battle.Fmlv.Write(stream,fmlvStream);
-            });
-
-            var testFmlv = new FmlvDTO
-            {
-                Unk0 = 17,
-                LevelGrowthAbility = 1,
-                Ability = 17,
-                Exp = 1,
-                FormId = 1,
-                FormLevel = 1,
-                FormVanilla = Kh2.Battle.Fmlv.FormVanilla.Valor,
-                FormFm = Kh2.Battle.Fmlv.FormFm.Valor
-            };
-
-            var fmlvDict = new Dictionary<Kh2.Battle.Fmlv.FormFm, List<FmlvDTO>>();
-            fmlvDict.Add(Kh2.Battle.Fmlv.FormFm.Valor, new List<FmlvDTO>() { testFmlv });
-
-            File.WriteAllText(Path.Combine(ModInputDir, "FmlvList.yml"), serializer.Serialize(fmlvDict));
-
-            #endregion
-
-            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
-
-            AssertFileExists(ModOutputDir, "fmlv.bin");
-
-            File.OpenRead(Path.Combine(ModOutputDir, "fmlv.bin")).Using(stream =>
-            {
-                var fmlv = Kh2.Battle.Fmlv.Read(stream);
-                Assert.True(fmlv[0].Exp == testFmlv.Exp);
-                Assert.True(fmlv[0].Ability == testFmlv.Ability);
-            });
-        }
-
-        [Fact]
-        public void ListReplaceLvupTest()
-        {
-            var patcher = new PatcherProcessor();
-            var serializer = new Serializer();
-            var patch = new Metadata
-            {
-                Assets = new List<AssetFile>
-                {
-                new AssetFile
-                {
-                    Name = "lvup.bin",
-                    Method = "binarc",
-                    Source = new List<AssetFile>
-                    {
-                        new AssetFile
-                        {
-                            Name = "lvup",
-                            Method = "listreplace",
-                            Type = "List",
-                            Source = new List<AssetFile>
-                            {
-                                new AssetFile
-                                {
-                                    Name = "LvupList.yml",
-                                    Type = "lvup"
-                                }
-                            }
-                        }
-                    }
-                }
-                }
-            };
-
-            #region lvupPatch
-
-            File.Create(Path.Combine(AssetsInputDir, "lvup.bin")).Using(stream =>
-            {
-                var fmlvStream = new Kh2.Battle.Lvup
-                {
-                    Characters = new List<Kh2.Battle.Lvup.PlayableCharacter>
-                    {
-                        new Kh2.Battle.Lvup.PlayableCharacter
-                        {
-                            NumLevels = 99,
-                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>
-                            {
-                                new Kh2.Battle.Lvup.PlayableCharacter.Level
-                                {
-                                    Exp = 1000,
-                                    Ap = 3,
-                                    Strength = 4,
-                                    Magic = 5,
-                                    Defense = 6,
-                                    SwordAbility = 100,
-                                    ShieldAbility = 101,
-                                    StaffAbility = 102
-                                }
-                            }
-                        }
-                    }
-                };
-                fmlvStream.Write(stream);
-            });
-
-            var soraLevel0 = new Kh2.Battle.Lvup.PlayableCharacter.Level
-            {
-                Exp = 100,
-                Ap = 99,
-                Strength = 40,
-                Magic = 50,
-                Defense = 60,
-                SwordAbility = 152,
-                ShieldAbility = 153,
-                StaffAbility = 154
-            };
-
-            var testLvup = new Kh2.Battle.Lvup
-            {
-                Characters = new List<Kh2.Battle.Lvup.PlayableCharacter>
-                {
-                    new Kh2.Battle.Lvup.PlayableCharacter
-                    {
-                        NumLevels = 99,
-                        Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>
-                        {
-                            soraLevel0
-                        }
-                    }
-                }
-            };
-
-
-            File.WriteAllText(Path.Combine(ModInputDir, "LvupList.yml"), serializer.Serialize(testLvup));
-
-            #endregion
-
-            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
-
-            AssertFileExists(ModOutputDir, "lvup.bin");
-
-            File.OpenRead(Path.Combine(ModOutputDir, "lvup.bin")).Using(stream =>
-            {
-                var lvup = Kh2.Battle.Lvup.Read(stream);
-                Assert.True(lvup.Characters[0].Levels[0] == soraLevel0);
-            });
-        }
-
-        [Fact]
-        public void ListReplaceBonsTest()
-        {
-            var patcher = new PatcherProcessor();
-            var serializer = new Serializer();
-            var patch = new Metadata
-            {
-                Assets = new List<AssetFile>
-                {
-                new AssetFile
-                {
-                    Name = "bons.bin",
-                    Method = "binarc",
-                    Source = new List<AssetFile>
-                    {
-                        new AssetFile
-                        {
-                            Name = "bons",
-                            Method = "listreplace",
-                            Type = "List",
-                            Source = new List<AssetFile>
-                            {
-                                new AssetFile
-                                {
-                                    Name = "BonsList.yml",
-                                    Type = "bons"
-                                }
-                            }
-                        }
-                    }
-                },
-                }
-            };
-
-            #region bonsPatch
-
-            File.Create(Path.Combine(AssetsInputDir, "bons.bin")).Using(stream =>
-            {
-                var bonsStream = new Kh2.Battle.Bons
-                {
-                    CharacterId = 0,
-                    RewardId = 1,
-                    BonusItem1 = 10,
-                    BonusItem2 = 20
-                };
-                Kh2.Battle.Bons.Write(stream, new List<Kh2.Battle.Bons> { bonsStream });
-            });
-
-            var testBons = new List<Kh2.Battle.Bons>
-            {
-                new Kh2.Battle.Bons
-                {
-                    CharacterId = 0,
-                    RewardId = 1,
-                    BonusItem1 = 100,
-                    BonusItem2 = 200
-                }
-            };
-
-            File.WriteAllText(Path.Combine(ModInputDir, "BonsList.yml"), serializer.Serialize(testBons));
-
-            #endregion
-
-            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
-
-            AssertFileExists(ModOutputDir, "bons.bin");
-
-            File.OpenRead(Path.Combine(ModOutputDir, "bons.bin")).Using(stream =>
-            {
-                var bons = Kh2.Battle.Bons.Read(stream);
-                Assert.True(bons[0] == testBons[0]);
-            });
-        }
-
-        [Fact]
         public void ListReplaceTrsrTest()
         {
             var patcher = new PatcherProcessor();
             var serializer = new Serializer();
-            var patch = new Metadata
-            {
-                Assets = new List<AssetFile>
+            var patch = new Metadata() { 
+                Assets = new List<AssetFile>()
                 {
-                new AssetFile
-                {
-                    Name = "trsr.bin",
-                    Method = "binarc",
-                    Source = new List<AssetFile>
+                    new AssetFile()
                     {
-                        new AssetFile
+                        Name = "03system.bar",
+                        Method = "binarc",
+                        Source = new List<AssetFile>()
                         {
-                            Name = "trsr",
-                            Method = "listreplace",
-                            Type = "List",
-                            Source = new List<AssetFile>
+                            new AssetFile()
                             {
-                                new AssetFile
+                                Name = "trsr",
+                                Method = "listreplace",
+                                Type = "List",
+                                Source = new List<AssetFile>()
                                 {
-                                    Name = "TrsrList.yml",
-                                    Type = "trsr"
+                                    new AssetFile()
+                                    {
+                                        Name = "TrsrList.yml",
+                                        Type = "trsr"
+                                    }
                                 }
                             }
                         }
                     }
                 }
-                }
             };
 
-            #region trsrPatch
-            File.Create(Path.Combine(AssetsInputDir, "trsr.bin")).Using(stream =>
+            File.Create(Path.Combine(AssetsInputDir, "03system.bar")).Using(stream =>
             {
-                var trsrStream = new Kh2.SystemData.Trsr
+                var trsrEntry = new List<Kh2.SystemData.Trsr>()
                 {
-                    Id = 120,
-                    ItemId = 10
-                };
-                Kh2.SystemData.Trsr.Write(stream, new List<Kh2.SystemData.Trsr>
-                {
-                    trsrStream
+                    new Kh2.SystemData.Trsr
+                    {
+                        Id = 1,
+                        ItemId = 10
+                    }
+                    };
+                using var trsrStream = new MemoryStream();
+                Kh2.SystemData.Trsr.Write(trsrStream, trsrEntry);
+                Bar.Write(stream, new Bar() {
+                    new Bar.Entry()
+                    {
+                        Name = "trsr",
+                        Type = Bar.EntryType.List,
+                        Stream = trsrStream
+                    }
                 });
             });
 
-            var testTrsr = new List<Kh2.SystemData.Trsr>
+            File.Create(Path.Combine(ModInputDir, "TrsrList.yml")).Using(stream =>
             {
-                new Kh2.SystemData.Trsr
-                {
-                    Id = 120,
-                    ItemId = 100
-                }
-            };
-
-            File.WriteAllText(Path.Combine(ModInputDir, "TrsrList.yml"), serializer.Serialize(testTrsr));
-            #endregion
+                var writer = new StreamWriter(stream);
+                writer.WriteLine("1:");
+                writer.WriteLine("  Id: 1");
+                writer.WriteLine("  ItemId: 200");
+                writer.Flush();
+            });
 
             patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
 
-            AssertFileExists(ModOutputDir, "trsr.bin");
+            AssertFileExists(ModOutputDir, "03system.bar");
 
-            File.OpenRead(Path.Combine(ModOutputDir, "trsr.bin")).Using(stream =>
-            {
-                var trsr = Kh2.SystemData.Trsr.Read(stream);
-                Assert.True(trsr[0] == testTrsr[0]);
-            });
+            File.OpenRead(Path.Combine(ModOutputDir, "03system.bar")).Using(stream =>
+             {
+                 var binarc = Bar.Read(stream);
+                 var trsrStream = Kh2.SystemData.Trsr.Read(binarc[0].Stream);
+                 Assert.True(trsrStream[0].ItemId == 200);
+             });
+
         }
 
         [Fact]
@@ -855,95 +596,348 @@ namespace OpenKh.Tests.Patcher
         {
             var patcher = new PatcherProcessor();
             var serializer = new Serializer();
-            var patch = new Metadata
+            var patch = new Metadata()
             {
-                Assets = new List<AssetFile>
-                { 
-                new AssetFile
+                Assets = new List<AssetFile>()
                 {
-                    Name = "item.bin",
-                    Method = "binarc",
-                    Source = new List<AssetFile>
+                    new AssetFile()
                     {
-                        new AssetFile
+                        Name = "03system.bar",
+                        Method = "binarc",
+                        Source = new List<AssetFile>()
                         {
-                            Name = "item",
-                            Method = "listreplace",
-                            Type = "List",
-                            Source = new List<AssetFile>
+                            new AssetFile()
                             {
-                                new AssetFile
+                                Name = "item",
+                                Method = "listreplace",
+                                Type = "List",
+                                Source = new List<AssetFile>()
                                 {
-                                    Name = "ItemList.yml",
-                                    Type = "item"
+                                    new AssetFile()
+                                    {
+                                        Name = "ItemList.yml",
+                                        Type = "item"
+                                    }
                                 }
                             }
                         }
                     }
                 }
-                }
             };
 
-            #region itemPatch
-            File.Create(Path.Combine(AssetsInputDir, "item.bin")).Using(stream =>
+            File.Create(Path.Combine(AssetsInputDir, "03system.bar")).Using(stream =>
             {
-                var itemStream = new Kh2.SystemData.Item
+                var itemEntry = new List<Kh2.SystemData.Item>()
                 {
-                    Items1 = new List<Kh2.SystemData.Item.Entry>
+                    new Kh2.SystemData.Item
                     {
-                        new Kh2.SystemData.Item.Entry
+                        Items1 = new List<Kh2.SystemData.Item.Entry>()
                         {
-                            Id = 130,
-                            ShopSell = 10
-                        }
-                    },
-                    Items2 = new List<Kh2.SystemData.Item.Stat>
-                    {
-                        new Kh2.SystemData.Item.Stat
+                            new Kh2.SystemData.Item.Entry()
+                            {
+                                Id = 1,
+                                ShopBuy = 10
+                            }
+                        },
+                        Items2 = new List<Kh2.SystemData.Item.Stat>()
                         {
-                            Id = 140,
-                            Ability = 10
+                            new Kh2.SystemData.Item.Stat()
+                            {
+                                Id = 10,
+                                Ability = 15
+                            }
                         }
+                        
                     }
-                };
-                itemStream.Write(stream);
+                    };
+                using var itemStream = new MemoryStream();
+                itemEntry[0].Write(itemStream);
+                Bar.Write(stream, new Bar() {
+                    new Bar.Entry()
+                    {
+                        Name = "item",
+                        Type = Bar.EntryType.List,
+                        Stream = itemStream
+                    }
+                });
             });
 
-            var testItem = new Kh2.SystemData.Item
+            File.Create(Path.Combine(ModInputDir, "ItemList.yml")).Using(stream =>
             {
-                Items1 = new List<Kh2.SystemData.Item.Entry>
-                {
-                    new Kh2.SystemData.Item.Entry
-                    {
-                        Id = 130,
-                        ShopSell = 100
-                    }
-                },
-                Items2 = new List<Kh2.SystemData.Item.Stat>
-                {
-                    new Kh2.SystemData.Item.Stat
-                    {
-                        Id = 140,
-                        Ability = 100
-                    }
-                }
-            };
-
-            File.WriteAllText(Path.Combine(ModInputDir, "ItemList.yml"), serializer.Serialize(testItem));
-
-
-
-            #endregion
+                var writer = new StreamWriter(stream);
+                writer.WriteLine("Items1:");
+                writer.WriteLine("- Id: 1");
+                writer.WriteLine("  ShopBuy: 200");
+                writer.WriteLine("Items2:");
+                writer.WriteLine("- Id: 10");
+                writer.WriteLine("  Ability: 150");
+                writer.Flush();
+            });
 
             patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
 
-            AssertFileExists(ModOutputDir, "item.bin");
+            AssertFileExists(ModOutputDir, "03system.bar");
 
-            File.OpenRead(Path.Combine(ModOutputDir, "item.bin")).Using(stream =>
+            File.OpenRead(Path.Combine(ModOutputDir, "03system.bar")).Using(stream =>
             {
-                var item = Kh2.SystemData.Item.Read(stream);
-                Assert.True(item.Items1[0] == testItem.Items1[0]);
-                Assert.True(item.Items2[0] == testItem.Items2[0]);
+                var binarc = Bar.Read(stream);
+                var itemStream = Kh2.SystemData.Item.Read(binarc[0].Stream);
+                Assert.True(itemStream.Items1[0].ShopBuy == 200);
+                Assert.True(itemStream.Items2[0].Ability == 150);
+            });
+
+        }
+
+        [Fact]
+        public void ListReplaceFmlvTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata()
+            {
+                Assets = new List<AssetFile>()
+                {
+                    new AssetFile()
+                    {
+                        Name = "00battle.bar",
+                        Method = "binarc",
+                        Source = new List<AssetFile>()
+                        {
+                            new AssetFile()
+                            {
+                                Name = "fmlv",
+                                Method = "listreplace",
+                                Type = "List",
+                                Source = new List<AssetFile>()
+                                {
+                                    new AssetFile()
+                                    {
+                                        Name = "FmlvList.yml",
+                                        Type = "fmlv"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            File.Create(Path.Combine(AssetsInputDir, "00battle.bar")).Using(stream =>
+            {
+                var fmlvEntry = new List<Kh2.Battle.Fmlv.Level>()
+                {
+                    new Kh2.Battle.Fmlv.Level
+                    {
+                        FormId = 1,
+                        FormLevel = 1,
+                        FormFm = Kh2.Battle.Fmlv.FormFm.Valor,
+                        FormVanilla = Kh2.Battle.Fmlv.FormVanilla.Valor,
+                        Exp= 100
+                    }
+                    };
+                using var fmlvStream = new MemoryStream();
+                Kh2.Battle.Fmlv.Write(fmlvStream, fmlvEntry);
+                Bar.Write(stream, new Bar() {
+                    new Bar.Entry()
+                    {
+                        Name = "fmlv",
+                        Type = Bar.EntryType.List,
+                        Stream = fmlvStream
+                    }
+                });
+            });
+
+            File.Create(Path.Combine(ModInputDir, "FmlvList.yml")).Using(stream =>
+            {
+                var writer = new StreamWriter(stream);
+                writer.WriteLine("Valor:");
+                writer.WriteLine("- FormId: 1");
+                writer.WriteLine("  FormLevel: 1");
+                writer.WriteLine("  FormFm: Valor");
+                writer.WriteLine("  FormVanilla: Valor");
+                writer.WriteLine("  Exp: 5");
+                writer.Flush();
+            });
+
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
+
+            AssertFileExists(ModOutputDir, "00battle.bar");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "00battle.bar")).Using(stream =>
+            {
+                var binarc = Bar.Read(stream);
+                var fmlvStream = Kh2.Battle.Fmlv.Read(binarc[0].Stream);
+                Assert.True(fmlvStream[0].Exp == 5);
+            });
+
+        }
+
+        [Fact]
+        public void ListReplaceBonsTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata()
+            {
+                Assets = new List<AssetFile>()
+                {
+                    new AssetFile()
+                    {
+                        Name = "00battle.bar",
+                        Method = "binarc",
+                        Source = new List<AssetFile>()
+                        {
+                            new AssetFile()
+                            {
+                                Name = "bons",
+                                Method = "listreplace",
+                                Type = "List",
+                                Source = new List<AssetFile>()
+                                {
+                                    new AssetFile()
+                                    {
+                                        Name = "BonsList.yml",
+                                        Type = "bons"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            File.Create(Path.Combine(AssetsInputDir, "00battle.bar")).Using(stream =>
+            {
+                var bonsEntry = new List<Kh2.Battle.Bons>()
+                {
+                    new Kh2.Battle.Bons
+                    {
+                        CharacterId = 1,
+                        RewardId = 15,
+                        BonusItem1 = 10
+                    }
+                    };
+                using var bonsStream = new MemoryStream();
+                Kh2.Battle.Bons.Write(bonsStream, bonsEntry);
+                Bar.Write(stream, new Bar() {
+                    new Bar.Entry()
+                    {
+                        Name = "bons",
+                        Type = Bar.EntryType.List,
+                        Stream = bonsStream
+                    }
+                });
+            });
+
+            File.Create(Path.Combine(ModInputDir, "BonsList.yml")).Using(stream =>
+            {
+                var writer = new StreamWriter(stream);
+                writer.WriteLine("15Sora:");
+                writer.WriteLine("  RewardId: 15");
+                writer.WriteLine("  CharacterId: 1");
+                writer.WriteLine("  BonusItem1: 200");
+                writer.Flush();
+            });
+
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
+
+            AssertFileExists(ModOutputDir, "00battle.bar");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "00battle.bar")).Using(stream =>
+            {
+                var binarc = Bar.Read(stream);
+                var bonsStream = Kh2.Battle.Bons.Read(binarc[0].Stream);
+                Assert.True(bonsStream[0].BonusItem1 == 200);
+            });
+
+        }
+
+        [Fact]
+        public void ListReplaceLvupTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata()
+            {
+                Assets = new List<AssetFile>()
+                {
+                    new AssetFile()
+                    {
+                        Name = "00battle.bar",
+                        Method = "binarc",
+                        Source = new List<AssetFile>()
+                        {
+                            new AssetFile()
+                            {
+                                Name = "lvup",
+                                Method = "listreplace",
+                                Type = "List",
+                                Source = new List<AssetFile>()
+                                {
+                                    new AssetFile()
+                                    {
+                                        Name = "LvupList.yml",
+                                        Type = "lvup"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            File.Create(Path.Combine(AssetsInputDir, "00battle.bar")).Using(stream =>
+            {
+                var lvupEntry = new Kh2.Battle.Lvup
+                {
+                    Count = 1,
+                    Unknown08 = new byte[0x38],
+                    Characters = new List<Kh2.Battle.Lvup.PlayableCharacter>()
+                    {
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        }
+                    }
+                };
+                using var lvupStream = new MemoryStream();
+                lvupEntry.Write(lvupStream);
+                Bar.Write(stream, new Bar() {
+                    new Bar.Entry()
+                    {
+                        Name = "lvup",
+                        Type = Bar.EntryType.List,
+                        Stream = lvupStream
+                    }
+                });
+            });
+
+            File.Create(Path.Combine(ModInputDir, "LvupList.yml")).Using(stream =>
+            {
+                var writer = new StreamWriter(stream);
+                writer.WriteLine("Characters:");
+                writer.WriteLine("- NumLevels: 99");
+                writer.WriteLine("  Levels:");
+                writer.WriteLine("  - Exp: 500");
+                writer.Flush();
+            });
+
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
+
+            AssertFileExists(ModOutputDir, "00battle.bar");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "00battle.bar")).Using(stream =>
+            {
+                var binarc = Bar.Read(stream);
+                var lvupStream = Kh2.Battle.Lvup.Read(binarc[0].Stream);
+                Assert.True(lvupStream.Characters[0].Levels[0].Exp == 500);
             });
 
         }
@@ -1002,67 +996,7 @@ namespace OpenKh.Tests.Patcher
             }, ModOutputDir, patch.Assets[0].Multi[0].Name);
         }
 
-        [Fact]
-        public void ListReplaceObjEntryTest()
-        {
-            var patcher = new PatcherProcessor();
-            var serializer = new Serializer();
-            var patch = new Metadata
-            {
-                Assets = new List<AssetFile>
-                {
-                new AssetFile
-                {
-                    Name = "objentry.bin",
-                    Method = "listreplace",
-                    Source = new List<AssetFile>
-                    {
-                        new AssetFile
-                        {
-                            Name = "ObjEntryList.yml",
-                            Type = "objentry"
-                        }
-                    }
-                },
-                }
-            };
 
-            #region objEntryPatch
-
-            File.Create(Path.Combine(AssetsInputDir, "objentry.bin")).Using(stream =>
-            {
-                var objEntryStream = new Kh2.Objentry {
-                    ObjectId = 1,
-                    ModelName = "M_EX060"
-                };
-                Kh2.Objentry.Write(stream, new List<Kh2.Objentry> { objEntryStream });
-            });
-
-            var testObjEntry = new Dictionary<uint,Kh2.Objentry>
-            {
-                { 1,
-                new Kh2.Objentry
-                {
-                    ObjectId = 1,
-                    ModelName = "M_EX050"
-                }
-                }
-            };
-
-            File.WriteAllText(Path.Combine(ModInputDir, "ObjEntryList.yml"), serializer.Serialize(testObjEntry));
-
-            #endregion
-
-            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
-
-            AssertFileExists(ModOutputDir, "objentry.bin");
-
-            File.OpenRead(Path.Combine(ModOutputDir, "objentry.bin")).Using(stream =>
-            {
-                var objentry = Kh2.Objentry.Read(stream);
-                Assert.True(objentry[1] == testObjEntry[1]);
-            });
-        }
         private static void AssertFileExists(params string[] paths)
         {
             var filePath = Path.Join(paths);

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -552,35 +552,34 @@ namespace OpenKh.Tests.Patcher
 
             File.Create(Path.Combine(AssetsInputDir, "fmlv.bin")).Using(stream =>
             {
-                var fmlvStream = new List<Kh2.Battle.Fmlv>{
-                    new Kh2.Battle.Fmlv {
-                        Unk0 = 17,
-                        AbilityLevel = 0,
+                var fmlvStream = new List<Kh2.Battle.Fmlv.Level>{
+                    new Kh2.Battle.Fmlv.Level {
+                        LevelGrowthAbility = 0,
                         Ability = 1,
                         Exp = 70,
                         FormId = 1,
                         FormLevel = 1,
-                        VanillaForm = Kh2.Battle.Fmlv.FormVanilla.Valor,
-                        FinalMixForm = Kh2.Battle.Fmlv.FormFm.Valor
+                        FormVanilla = Kh2.Battle.Fmlv.FormVanilla.Valor,
+                        FormFm = Kh2.Battle.Fmlv.FormFm.Valor
                     }
                 };
                 Kh2.Battle.Fmlv.Write(stream,fmlvStream);
             });
 
-            var testFmlv = new Kh2.Battle.Fmlv
+            var testFmlv = new FmlvDTO
             {
                 Unk0 = 17,
-                AbilityLevel = 1,
+                LevelGrowthAbility = 1,
                 Ability = 17,
                 Exp = 1,
                 FormId = 1,
                 FormLevel = 1,
-                VanillaForm = Kh2.Battle.Fmlv.FormVanilla.Valor,
-                FinalMixForm = Kh2.Battle.Fmlv.FormFm.Valor
+                FormVanilla = Kh2.Battle.Fmlv.FormVanilla.Valor,
+                FormFm = Kh2.Battle.Fmlv.FormFm.Valor
             };
 
-            var fmlvDict = new Dictionary<Kh2.Battle.Fmlv.FormFm, List<Kh2.Battle.Fmlv>>();
-            fmlvDict.Add(Kh2.Battle.Fmlv.FormFm.Valor, new List<Kh2.Battle.Fmlv>() { testFmlv });
+            var fmlvDict = new Dictionary<Kh2.Battle.Fmlv.FormFm, List<FmlvDTO>>();
+            fmlvDict.Add(Kh2.Battle.Fmlv.FormFm.Valor, new List<FmlvDTO>() { testFmlv });
 
             File.WriteAllText(Path.Combine(ModInputDir, "FmlvList.yml"), serializer.Serialize(fmlvDict));
 
@@ -593,7 +592,8 @@ namespace OpenKh.Tests.Patcher
             File.OpenRead(Path.Combine(ModOutputDir, "fmlv.bin")).Using(stream =>
             {
                 var fmlv = Kh2.Battle.Fmlv.Read(stream);
-                Assert.True(fmlv[0] == testFmlv);
+                Assert.True(fmlv[0].Exp == testFmlv.Exp);
+                Assert.True(fmlv[0].Ability == testFmlv.Ability);
             });
         }
 

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -1055,10 +1055,9 @@ namespace OpenKh.Tests.Patcher
             File.Create(Path.Combine(ModInputDir, "LvupList.yml")).Using(stream =>
             {
                 var writer = new StreamWriter(stream);
-                writer.WriteLine("Characters:");
-                writer.WriteLine("- NumLevels: 99");
-                writer.WriteLine("  Levels:");
-                writer.WriteLine("  - Exp: 500");
+                writer.WriteLine("Sora:");
+                writer.WriteLine("  1:");
+                writer.WriteLine("    Exp: 500");
                 writer.Flush();
             });
 

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -863,7 +863,7 @@ namespace OpenKh.Tests.Patcher
                 {
                     new AssetFile()
                     {
-                        Name = "00battle.bar",
+                        Name = "00battle.bin",
                         Method = "binarc",
                         Source = new List<AssetFile>()
                         {
@@ -886,11 +886,11 @@ namespace OpenKh.Tests.Patcher
                 }
             };
 
-            File.Create(Path.Combine(AssetsInputDir, "00battle.bar")).Using(stream =>
+            File.Create(Path.Combine(AssetsInputDir, "00battle.bin")).Using(stream =>
             {
                 var lvupEntry = new Kh2.Battle.Lvup
                 {
-                    Count = 1,
+                    Count = 13,
                     Unknown08 = new byte[0x38],
                     Characters = new List<Kh2.Battle.Lvup.PlayableCharacter>()
                     {
@@ -904,7 +904,140 @@ namespace OpenKh.Tests.Patcher
                                     Exp = 50
                                 }
                             }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
+                        },
+                        new Kh2.Battle.Lvup.PlayableCharacter()
+                        {
+                            NumLevels = 1,
+                            Levels = new List<Kh2.Battle.Lvup.PlayableCharacter.Level>()
+                            {
+                                new Kh2.Battle.Lvup.PlayableCharacter.Level()
+                                {
+                                    Exp = 50
+                                }
+                            }
                         }
+
                     }
                 };
                 using var lvupStream = new MemoryStream();
@@ -931,13 +1064,76 @@ namespace OpenKh.Tests.Patcher
 
             patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
 
-            AssertFileExists(ModOutputDir, "00battle.bar");
+            AssertFileExists(ModOutputDir, "00battle.bin");
 
-            File.OpenRead(Path.Combine(ModOutputDir, "00battle.bar")).Using(stream =>
+            File.OpenRead(Path.Combine(ModOutputDir, "00battle.bin")).Using(stream =>
             {
                 var binarc = Bar.Read(stream);
                 var lvupStream = Kh2.Battle.Lvup.Read(binarc[0].Stream);
                 Assert.True(lvupStream.Characters[0].Levels[0].Exp == 500);
+            });
+
+        }
+
+        [Fact]
+        public void ListReplaceObjEntryTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata()
+            {
+                Assets = new List<AssetFile>()
+                {
+                    new AssetFile()
+                    {
+                        Name = "00objentry.bin",
+                        Method = "listreplace",
+                        Type = "List",
+                        Source = new List<AssetFile>()
+                        {
+                            new AssetFile()
+                            {
+                                Name = "ObjList.yml",
+                                Type = "objentry",
+                            }
+                        }
+                    }
+                }
+            };
+
+            File.Create(Path.Combine(AssetsInputDir, "00objentry.bin")).Using(stream =>
+            {
+                var objEntry = new List<Kh2.Objentry>()
+                {
+                    new Kh2.Objentry
+                    {
+                        ObjectId = 1,
+                        ModelName = "M_EX060",
+                        AnimationName = "M_EX060.mset"
+                    }
+                    };
+                Kh2.Objentry.Write(stream, objEntry);
+            });
+
+            File.Create(Path.Combine(ModInputDir, "ObjList.yml")).Using(stream =>
+            {
+                var writer = new StreamWriter(stream);
+                writer.WriteLine("1:");
+                writer.WriteLine("  ObjectId: 1");
+                writer.WriteLine("  ModelName: M_EX100");
+                writer.WriteLine("  AnimationName: M_EX100.mset");
+                writer.Flush();
+            });
+
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
+
+            AssertFileExists(ModOutputDir, "00objentry.bin");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "00objentry.bin")).Using(stream =>
+            {
+                var objStream = Kh2.Objentry.Read(stream);
+                Assert.True(objStream[0].ModelName == "M_EX100");
+                Assert.True(objStream[0].AnimationName == "M_EX100.mset");
             });
 
         }

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -732,7 +732,8 @@ namespace OpenKh.Tests.Patcher
                         FormLevel = 1,
                         FormFm = Kh2.Battle.Fmlv.FormFm.Valor,
                         FormVanilla = Kh2.Battle.Fmlv.FormVanilla.Valor,
-                        Exp= 100
+                        Exp= 100,
+                        Ability = 200
                     }
                     };
                 using var fmlvStream = new MemoryStream();
@@ -750,12 +751,19 @@ namespace OpenKh.Tests.Patcher
             File.Create(Path.Combine(ModInputDir, "FmlvList.yml")).Using(stream =>
             {
                 var writer = new StreamWriter(stream);
-                writer.WriteLine("Valor:");
-                writer.WriteLine("- FormId: 1");
-                writer.WriteLine("  FormLevel: 1");
-                writer.WriteLine("  FormFm: Valor");
-                writer.WriteLine("  FormVanilla: Valor");
-                writer.WriteLine("  Exp: 5");
+                var serializer = new Serializer();
+                serializer.Serialize(writer, new Dictionary<string, FmlvDTO[]>
+                {
+                    ["Valor"] = new[]
+                    {
+                        new FmlvDTO
+                        {
+                        FormLevel = 1,
+                        Experience = 5,
+                        Ability = 127
+                        }
+                    }
+                });
                 writer.Flush();
             });
 
@@ -768,6 +776,7 @@ namespace OpenKh.Tests.Patcher
                 var binarc = Bar.Read(stream);
                 var fmlvStream = Kh2.Battle.Fmlv.Read(binarc[0].Stream);
                 Assert.True(fmlvStream[0].Exp == 5);
+                Assert.True(fmlvStream[0].Ability == 127);
             });
 
         }

--- a/OpenKh.Tests/kh2/System03Tests.cs
+++ b/OpenKh.Tests/kh2/System03Tests.cs
@@ -61,8 +61,8 @@ namespace OpenKh.Tests.kh2
             public void CheckForLength() => File.OpenRead("kh2/res/item.bin").Using(stream =>
             {
                 var entries = Item.Read(stream);
-                Assert.Equal(535, entries.Items1.Count);
-                Assert.Equal(151, entries.Items2.Count);
+                Assert.Equal(535, entries.Items.Count);
+                Assert.Equal(151, entries.Stats.Count);
             });
 
             [Fact]

--- a/OpenKh.Tools.Kh2SystemEditor/ViewModels/ItemViewModel.cs
+++ b/OpenKh.Tools.Kh2SystemEditor/ViewModels/ItemViewModel.cs
@@ -91,16 +91,16 @@ namespace OpenKh.Tools.Kh2SystemEditor.ViewModels
         public ItemViewModel(IMessageProvider messageProvider) :
             this(messageProvider, new Item
             {
-                Items1 = new List<Item.Entry>(),
-                Items2 = new List<Item.Stat>()
+                Items = new List<Item.Entry>(),
+                Stats = new List<Item.Stat>()
             })
         { }
 
         private ItemViewModel(IMessageProvider messageProvider, Item item) :
-            this(messageProvider, item.Items1)
+            this(messageProvider, item.Items)
         {
             _messageProvider = messageProvider;
-            _item2 = item.Items2;
+            _item2 = item.Stats;
         }
 
         private ItemViewModel(IMessageProvider messageProvider, IEnumerable<Item.Entry> items) :
@@ -129,8 +129,8 @@ namespace OpenKh.Tools.Kh2SystemEditor.ViewModels
             var stream = new MemoryStream();
             new Item
             {
-                Items1 = UnfilteredItems.Select(x => x.Item).ToList(),
-                Items2 = _item2
+                Items = UnfilteredItems.Select(x => x.Item).ToList(),
+                Stats = _item2
             }.Write(stream);
 
             return stream;


### PR DESCRIPTION
Cleaned up version of PR #452 . Adds functionality to the Patcher Processor that enables editing the following files using YAML:

* 00battle.bin
  * Fmlv
  * Lvup
  * Bons
* 03system.bin
  * Trsr
  * Item
* 00objentry.bin