### PR TITLE
Attempt to fix auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,9 +6,10 @@ on:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v2
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2.3
         with:
           target: minor
           approve: true


### PR DESCRIPTION
Apparently the Auto Merge for Dependabot broke due to a recent security change from GitHub. As described [in this post](https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60#issuecomment-806170152) there is a fix. This PR implements that fix as an attempt to fix it.