### PR TITLE
Fix broken OpenKh.Command.IdxImg

### DIFF
--- a/OpenKh.Command.IdxImg/KingdomHearts1.cs
+++ b/OpenKh.Command.IdxImg/KingdomHearts1.cs
@@ -84,8 +84,6 @@ namespace OpenKh.Command.IdxImg
 
             private class ListCommand
             {
-                private Program Parent { get; set; }
-
                 [Required]
                 [FileExists]
                 [Argument(0, Description = "Path to the Kingdom Hearts ISO file")]

--- a/OpenKh.Command.IdxImg/KingdomHearts2.cs
+++ b/OpenKh.Command.IdxImg/KingdomHearts2.cs
@@ -26,8 +26,6 @@ namespace OpenKh.Command.IdxImg
 
             private class ExtractCommand
             {
-                private Program Parent { get; set; }
-
                 [Required]
                 [FileExists]
                 [Argument(0, Description = "Kingdom Hearts II IDX file")]
@@ -119,8 +117,6 @@ namespace OpenKh.Command.IdxImg
 
             private class ListCommand
             {
-                private Program Parent { get; set; }
-
                 [Required]
                 [FileExists]
                 [Argument(0, Description = "Kingdom Hearts II IDX file, paired with a IMG")]


### PR DESCRIPTION
The PR #459 introduced some regressions where it was no longer possible to use the tool at all but to extract KH1 game's data. This restores all the intended functionalities.