### PR TITLE
Add `plrp` modification to `listpatch` method.

### DIFF
--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -452,6 +452,17 @@ namespace OpenKh.Patcher
                             Kh2.Objentry.Write(stream.SetPosition(0), objEntryList.Values);
                             break;
 
+                        case "plrp":
+                            var plrpList = Kh2.Battle.Plrp.Read(stream);
+                            var moddedPlrp = deserializer.Deserialize<List<Kh2.Battle.Plrp>>(sourceText);
+                            foreach (var plrp in moddedPlrp)
+                            {
+                                var oldPlrp = plrpList.First(x => x.Character == plrp.Character && x.Difficulty == plrp.Difficulty);
+                                plrpList[plrpList.IndexOf(oldPlrp)] = plrp;
+                            }
+                            Kh2.Battle.Plrp.Write(stream.SetPosition(0), plrpList);
+                        break;
+
                         default:
                             break;
                     }

--- a/OpenKh.Tests/Patcher/PatcherTests.cs
+++ b/OpenKh.Tests/Patcher/PatcherTests.cs
@@ -1174,6 +1174,95 @@ namespace OpenKh.Tests.Patcher
         }
 
         [Fact]
+        public void ListPatchPlrpTest()
+        {
+            var patcher = new PatcherProcessor();
+            var serializer = new Serializer();
+            var patch = new Metadata()
+            {
+                Assets = new List<AssetFile>()
+                {
+                    new AssetFile()
+                    {
+                        Name = "00battle.bar",
+                        Method = "binarc",
+                        Source = new List<AssetFile>()
+                        {
+                            new AssetFile()
+                            {
+                                Name = "plrp",
+                                Method = "listpatch",
+                                Type = "List",
+                                Source = new List<AssetFile>()
+                                {
+                                    new AssetFile()
+                                    {
+                                        Name = "PlrpList.yml",
+                                        Type = "plrp"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            File.Create(Path.Combine(AssetsInputDir, "00battle.bar")).Using(stream =>
+            {
+                var plrpEntry = new List<Kh2.Battle.Plrp>()
+                {
+                    new Kh2.Battle.Plrp
+                    {
+                        Difficulty = 7,
+                        Character = 1,
+                        Ap = 2,
+                        Objects = new List<short>(new short[58])
+                    }
+                };
+
+                using var plrpStream = new MemoryStream();
+                Kh2.Battle.Plrp.Write(plrpStream, plrpEntry);
+                Bar.Write(stream, new Bar() {
+                    new Bar.Entry()
+                    {
+                        Name = "plrp",
+                        Type = Bar.EntryType.List,
+                        Stream = plrpStream
+                    }
+                });
+            });
+
+            File.Create(Path.Combine(ModInputDir, "PlrpList.yml")).Using(stream =>
+            {
+                var writer = new StreamWriter(stream);
+                var serializer = new Serializer();
+                var moddedPlrp = new List<Kh2.Battle.Plrp>{
+                    new Kh2.Battle.Plrp
+                    {
+                        Difficulty = 7,
+                        Character = 1,
+                        Ap = 200,
+                        Objects = new List<short>(new short[58])
+                    } 
+                };
+                writer.Write(serializer.Serialize(moddedPlrp));
+                writer.Flush();
+            });
+
+            patcher.Patch(AssetsInputDir, ModOutputDir, patch, ModInputDir);
+
+            AssertFileExists(ModOutputDir, "00battle.bar");
+
+            File.OpenRead(Path.Combine(ModOutputDir, "00battle.bar")).Using(stream =>
+            {
+                var binarc = Bar.Read(stream);
+                var plrp = Kh2.Battle.Plrp.Read(binarc[0].Stream);
+
+                Assert.Equal(200, plrp[0].Ap);
+            });
+        }
+
+        [Fact]
         public void ProcessMultipleTest()
         {
             var patcher = new PatcherProcessor();


### PR DESCRIPTION
Allows editing of the `plrp` list in `00battle.bin`. This enables easy modification of starting stats and inventories of Sora, Donald, Goofy, and any guest characters in Kingdom Hearts 2. This includes Critical Bonuses for Sora.

[PlrpList.txt](https://github.com/Xeeynamo/OpenKh/files/6236492/PlrpList.txt) is an example source list that includes Sora's starting inventory and stats for Critical and Non-Critical difficulties.