### PR TITLE
add missing europe product id kh2

### DIFF
--- a/OpenKh.Tools.ModsManager/Services/GameService.cs
+++ b/OpenKh.Tools.ModsManager/Services/GameService.cs
@@ -21,6 +21,7 @@ namespace OpenKh.Tools.ModsManager.Services
                     new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLPM_662.33;1" },
                     new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLUS_210.05;1" },
                     new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SCUS_210.05;1" },
+                    new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLES_541.14;1" },
                     new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLES_541.44;1" },
                     new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLES_542.32;1" },
                     new GameDetectorModel { FileName = "SYSTEM.CNF;1", ProductId = "SLES_542.33;1" },


### PR DESCRIPTION
One of the product id's for EU Vanilla KH2 was missing, preventing the mods manager from extracting it.