### PR TITLE
[Mod Manager] Create `internal` copy method type

### DIFF
--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -145,10 +145,18 @@ namespace OpenKh.Patcher
             if (assetFile.Source == null || assetFile.Source.Count == 0)
                 throw new Exception($"File '{assetFile.Name}' does not contain any source");
 
-            var srcFile = context.GetSourceModAssetPath(assetFile.Source[0].Name);
-            if (!File.Exists(srcFile))
-                throw new FileNotFoundException($"The mod does not contain the file {assetFile.Source[0].Name}", srcFile);
+            string srcFile; 
 
+            if (assetFile.Source[0].Type == "internal")
+            {
+                srcFile = context.GetOriginalAssetPath(assetFile.Source[0].Name);
+            }
+            else
+            {
+                srcFile = context.GetSourceModAssetPath(assetFile.Source[0].Name);
+                if (!File.Exists(srcFile))
+                    throw new FileNotFoundException($"The mod does not contain the file {assetFile.Source[0].Name}", srcFile);
+            }
             using var srcStream = File.OpenRead(srcFile);
             srcStream.CopyTo(stream);
         }


### PR DESCRIPTION
Adds the `internal` type parameter to the `copy` method. This allows mods to rearrange game assets without bundling them.

Template:

```
- method: copy
  name: $OUTPUT_FILE
  source:
  - name: $GAME_ASSET
    type: internal
```
Example:

```
- method: copy
  name: bgm/music097.win32.scd
  source:
  - name: bgm/music111.win32.scd
    type: internal
```

The above `mod.yml` entry copies the content of `bgm/music111.win32.scd` to `bgm/music097.win32.scd` in the mod output directory.