### PR TITLE
fixes to ard script parse

### DIFF
--- a/OpenKh.Kh2/Ard/AreaDataScript.cs
+++ b/OpenKh.Kh2/Ard/AreaDataScript.cs
@@ -126,6 +126,7 @@ namespace OpenKh.Kh2.Ard
             [0x0F] = typeof(Party),
             [0x10] = typeof(Bgm),
             [0x11] = typeof(MsgWall),
+            [0x12] = typeof(AllocPacket),
             [0x13] = typeof(Camera),
             [0x14] = typeof(StatusFlag3),
             [0x15] = typeof(Mission),
@@ -233,11 +234,11 @@ namespace OpenKh.Kh2.Ard
 
         public class Capacity : IAreaDataCommand
         {
-            [Data] public float Value { get; set; }
+            [Data] public int Value { get; set; }
 
             public void Parse(int nRow, List<string> tokens)
             {
-                Value = ParseAsFloat(nRow, GetToken(nRow, tokens, 1));
+                Value = ParseAsInt(nRow, GetToken(nRow, tokens, 1));
             }
 
             public override string ToString() =>
@@ -250,6 +251,19 @@ namespace OpenKh.Kh2.Ard
 
             public override string ToString() =>
                 $"{nameof(AllocEnemy)} {Value}";
+
+            public void Parse(int nRow, List<string> tokens)
+            {
+                Value = ParseAsInt(nRow, GetToken(nRow, tokens, 1));
+            }
+        }
+
+        public class AllocPacket : IAreaDataCommand
+        {
+            [Data] public int Value { get; set; }
+
+            public override string ToString() =>
+                $"{nameof(AllocPacket)} {Value}";
 
             public void Parse(int nRow, List<string> tokens)
             {
@@ -527,7 +541,6 @@ namespace OpenKh.Kh2.Ard
 
             public void Parse(int nRow, List<string> tokens)
             {
-                Value = ParseAsInt(nRow, GetToken(nRow, tokens, 1));
                 throw new Exception($"Parsing an '{nameof(If)}' is not yet supported");
             }
 

--- a/OpenKh.Tests/kh2/ArdTests.cs
+++ b/OpenKh.Tests/kh2/ArdTests.cs
@@ -82,7 +82,7 @@ namespace OpenKh.Tests.kh2
             [InlineData("MapVisibility 0xffffffff 0x00000001", 1, -1, 1)]
             [InlineData("RandomSpawn \"0123\" \"4567\"", 2, 0x33323130, 0x37363534)]
             [InlineData("CasualSpawn 123 \"666\"", 3, 123, 0x363636)]
-            [InlineData("Capacity 123", 4, 0x42F60000)]
+            [InlineData("Capacity 123", 4, 123)]
             [InlineData("AllocEnemy 123", 5, 123)]
             [InlineData("Unk06 123", 6, 123)]
             [InlineData("Unk07 123", 7, 123)]

--- a/docs/kh2/file/type/areadata.md
+++ b/docs/kh2/file/type/areadata.md
@@ -208,7 +208,7 @@ There is a total of 30 operation codes for the spawn script. The parser can be f
 - 0f: [Party](#party)
 - 10: [Bgm](#bgm)
 - 11: [MsgWall](#msgwall)
-- 12: [unknown](#unknown12)
+- 12: [AllocPacket](#allocpacket)
 - 13: [Camera](#camera)
 - 14: [StatusFlag3](#statusflag3)
 - 15: [Mission](#mission)
@@ -244,7 +244,7 @@ Very uncommon, used 17 times and only in the worlds BB, CA, LK and MU.
 
 #### Capacity
 
-Set the memory area `01c6053c`, which represents a floating number that holds the capacity of the current map. The bigger is the capacity the better is the amount of enemies that can be loaded at once. It's found 465 times and only in `btl`.
+Set the memory area `01c6053c`, which represents an integer that holds the capacity of the current map. The bigger is the capacity the better is the amount of enemies that can be loaded at once. It's found 465 times and only in `btl`.
 
 #### AllocEnemy
 
@@ -300,9 +300,9 @@ Set the map's background musics. The single 4-byte parameter can be read as two 
 
 Set the memory area `0034ece4`, which represents the message displayed below when the player touches an invisible wall. Found 80 times and only in `map`.
 
-#### Unknown12
+#### AllocPacket
 
-Set the memory area `0034ecd4`. This opcode is unused.
+Set the memory area `0034ecd4`, which is related to the amount of memory reserved for the cache buffer. This opcode is unused.
 
 #### Unknown13
 


### PR DESCRIPTION
Makes 3 small adjustments

1 - Changes capacity from a float to an int, after careful testing in game and review of the disassembly
2 - Adds AllocPacket, which is unused in the actual game but is supported and can seemingly give memory related benefits to the PC version for modding
3 - Makes the If command actually throw a proper exception instead of failing on a bad parseInt