### PR TITLE
Add KH1 MDLS dictionary + made index pages slightly better to "traverse"

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 OpenKH - Open Kingdom Hearts Research and Development
-Copyright 2019-2020 OpenKH Team and Contributors
+Copyright 2019-2022 OpenKH Team and Contributors
 
 This product includes software developed at
-The OpenKH GitHub Repository (https://github.com/Xeeynamo/OpenKh/).
+The OpenKH GitHub Repository (https://git.openkh.dev/).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
 theme: jekyll-theme-hacker
 title: OpenKh
-description: This is a project centralizes all the technical knowledge of Kingdom Hearts series in one place, providing documentation, tools, code libraries and the foundation for modding the commercial games.
+description: This is a centralized place for the documentation and other discoveries about the internal working of Kingdom Hearts games.
 google_analytics: UA-56422469-2

--- a/docs/bbs/index.md
+++ b/docs/bbs/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts Birth By Sleep
+# Kingdom Hearts Birth By Sleep - Back to [Index](../index.md)
 
 ## General documentation
 
@@ -12,7 +12,6 @@
     * [CTD text format](file//type/ctd.md)
     * [Events](file//type/events.md)
 
-* [Network packages](network-packages.md)
 * Other files
     * [font.arc, fonten.arc](font.md)
 

--- a/docs/bbs/index.md
+++ b/docs/bbs/index.md
@@ -12,6 +12,7 @@
     * [CTD text format](file//type/ctd.md)
     * [Events](file//type/events.md)
 
+* [Network packages](network-packages.md)
 * Other files
     * [font.arc, fonten.arc](font.md)
 

--- a/docs/com/index.md
+++ b/docs/com/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts Chain of Memories
+# Kingdom Hearts Chain of Memories - Back to [Index](../index.md)
 
 ## General Documentation
 

--- a/docs/common/hdassets.md
+++ b/docs/common/hdassets.md
@@ -1,4 +1,4 @@
-# HD assets
+# HD assets - Back to [Index](../index.md)
 
 PS4 versions of Kingdom Hearts (and probably other PS3/PS4 remasters) add a special header to every file to override a specific texture or sound file.
 
@@ -6,6 +6,6 @@ For example, the file `arc_en/boss/b01dc00.arc` is the original file found in Fi
 
 If a file does not contain any remastered asset (like raw binary files that contains only gameplay data) have just the minimum header.
 
-## Tools
+## Tools (Under Construction)
 
-[OpenKh.Command.HdAssets](../tool/OpenKh.Command.HdAssets.md)
+[OpenKh.Command.HdAssets](../tool/CLI.HdAssets.md)

--- a/docs/common/tm2.md
+++ b/docs/common/tm2.md
@@ -1,4 +1,4 @@
-# TM2 - PlayStation 2 texture format
+# TM2 (PlayStation 2 texture format) - Back to [Index](../index.md)
 
 As the title suggests, this is the texture format used by PlayStation 2 games, not only Kingdom Hearts.
 

--- a/docs/ddd/index.md
+++ b/docs/ddd/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts Dream Drop Distance
+# Kingdom Hearts Dream Drop Distance - Back to [Index](../index.md)
 
 ## General Documentation
 

--- a/docs/engine/index.md
+++ b/docs/engine/index.md
@@ -1,4 +1,4 @@
-# OpenKH Game Engine
+# OpenKH Game Engine - Back to [Index](../index.md)
 
 The OpenKH Game Engine aims to re-create the same experience for games from Kingdom Hearts 1 to Kingdom Hearts Dream Drop Distance, allowing to mix assets between those games and unleash modding by expanding the source code or from just unchain the games from the hardware limitations of their original hardwares.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,8 @@
 # Kingdom Hearts Hacking Community
 
-This is a central place for documentation and discoveries about Kingdom Hearts games.
+This is a centralized place for the documentation and other discoveries about the internal working of Kingdom Hearts games.
 
-Every contribution is more than welcome!
-
-Right now the documentation contains info about the following games:
+As of right now, the documentation contains info about the following games:
 
 * [Kingdom Hearts I](kh1/index.md)
 * [Kingdom Hearts II](kh2/index.md)
@@ -27,3 +25,7 @@ Right now the documentation contains info about the following games:
   * [PS4 HD assets](common/hdassets.md)
 * [Tools](tool/index.md)
 * [OpenKH Game Engine](engine/index.md)
+
+### Contributions are more than welcome where applicable!
+
+For more information about contributing, visit our [Contributing](https://github.com/Xeeynamo/OpenKh/blob/master/CONTRIBUTING.md) page. 

--- a/docs/kh1/dictionary/mdls.md
+++ b/docs/kh1/dictionary/mdls.md
@@ -1,0 +1,503 @@
+# [Kingdom Hearts](../index.md) - Models (Characters)
+
+| Filename | Character | 
+|----------|-----------|
+| xa_al_0030.mdls | Aladdin | 
+| xa_al_0038.mdls | Aladdin | 
+| xa_al_0039.mdls | Aladdin | 
+| xa_al_1000.mdls | Jasmine | 
+| xa_al_1008.mdls | Jasmine | 
+| xa_al_1009.mdls | Jasmine | 
+| xa_al_1010.mdls | Magic Carpet | 
+| xa_al_1019.mdls | Magic Carpet | 
+| xa_al_1020.mdls | Iago (Parrot) | 
+| xa_al_1028.mdls | Iago (Parrot) | 
+| xa_al_1029.mdls | Iago (Parrot) | 
+| xa_al_1030.mdls | Random NPC | 
+| xa_al_1040.mdls | Random NPC | 
+| xa_al_1050.mdls | Random NPC | 
+| xa_al_1060.mdls | The Peddler | 
+| xa_al_1070.mdls | Random NPC | 
+| xa_al_1080.mdls | Babu | 
+| xa_al_1089.mdls | Babu | 
+| xa_al_2010.mdls | Dark Lamp (Jafar's | Lamp) | 
+| xa_al_3010.mdls | Jafar | 
+| xa_al_3018.mdls | Jafar | 
+| xa_al_3019.mdls | Jafar | 
+| xa_al_3020.mdls | Jafar Genie | 
+| xa_al_3029.mdls | Jafar Genie | 
+| xa_al_3030.mdls | Pot Centipede (Piece 1) | 
+| xa_al_3040.mdls | Pot Centipede (Piece 2) | 
+| xa_al_3050.mdls | Kurt Zisa | 
+| xa_al_3059.mdls | Kurt Zisa | 
+| xa_al_3060.mdls | Cave of Wonders | Guardian (Tiger Head) | 
+| xa_al_7000.mdls | Aladdin (High-Poly) | 
+| xa_al_7010.mdls | Jafar (High-Poly) | 
+| xa_al_7020.mdls | Genie (High-Poly) | 
+| xa_aw_1000.mdls | White Rabbit | 
+| xa_aw_1009.mdls | White Rabbit | 
+| xa_aw_1010.mdls | Queen of Hearts | 
+| xa_aw_1011.mdls | Queen of Hearts | 
+| xa_aw_1019.mdls | Queen of Hearts | 
+| xa_aw_1020.mdls | Cheshire Cat | 
+| xa_aw_1029.mdls | Cheshire Cat | 
+| xa_aw_1030.mdls | Ace of Spade Card | 
+| xa_aw_1031.mdls | Ace of Spade Card  | 
+| xa_aw_1039.mdls | Ace of Spade Card  | 
+| xa_aw_1060.mdls | Ace of Hearts | Card | 
+| xa_aw_1061.mdls | Ace of Hearts | Card | 
+| xa_aw_1069.mdls | Ace of Hearts | Card | 
+| xa_aw_1090.mdls | Door knob | 
+| xa_aw_1099.mdls | Door knob | 
+| xa_aw_3000.mdls | Trickmaster | 
+| xa_aw_3009.mdls | Trickmaster | 
+| xa_aw_7000.mdls | Queen of Hearts | (High-Poly) | 
+| xa_dc_1000.mdls | Donald (Wizard) | 
+| xa_dc_1010.mdls | Goofy (Knight) | 
+| xa_dc_1020.mdls | Mini Mouse | 
+| xa_dc_1029.mdls | Mini Mouse | 
+| xa_dc_1030.mdls | Daisy | 
+| xa_dc_1039.mdls | Daisy | 
+| xa_dc_1040.mdls | Chip | 
+| xa_dc_1049.mdls | Chip | 
+| xa_dc_1050.mdls | Dale | 
+| xa_dc_1059.mdls | Dale | 
+| xa_dc_1060.mdls | Magic Broom | 
+| xa_dc_1069.mdls | Magic Broom | 
+| xa_dc_1070.mdls | Jimminy Cricket | 
+| xa_dc_1079.mdls | Jimminy Cricket | 
+| xa_dh_1010.mdls | Dream Sword | 
+| xa_dh_1020.mdls | Dream Shield | 
+| xa_dh_1030.mdls | Dream Wand | 
+| xa_di_1000.mdls | Seagull | 
+| xa_di_1010.mdls | Tidus | 
+| xa_di_1019.mdls | Tidus | 
+| xa_di_1020.mdls | Selphie | 
+| xa_di_1029.mdls | Selphie | 
+| xa_di_1030.mdls | Wakka | 
+| xa_di_1039.mdls | Wakka | 
+| xa_di_1041.mdls | Fish | 
+| xa_di_3000.mdls | Darkside | 
+| xa_di_3001.mdls | Darkside | 
+| xa_di_3009.mdls | Darkside | 
+| xa_ew_2010.mdls | Bit Sniper | 
+| xa_ew_2020.mdls | Part of Ansem Boss | (Structure) | 
+| xa_ew_2030.mdls | Part of Ansem Boss | (Structure) | 
+| xa_ew_2040.mdls | Part of Ansem Boss | (Monster Face) | 
+| xa_ew_2050.mdls | Part of Ansem Boss | (Structure) | 
+| xa_ew_2060.mdls | End of World Piece? (unknown) | 
+| xa_ew_3020.mdls | Ansem (Final Boss) | 
+| xa_ex_0010.mdls | Sora | 
+| xa_ex_0012.mdls | Sora | 
+| xa_ex_0019.mdls | Sora | 
+| xa_ex_0040.mdls | Donald | 
+| xa_ex_0048.mdls | Donald | 
+| xa_ex_0049.mdls | Donald | 
+| xa_ex_0050.mdls | Goofy | 
+| xa_ex_0058.mdls | Goofy | 
+| xa_ex_0059.mdls | Goofy | 
+| xa_ex_1010.mdls | Riku (Wooden Sword) | 
+| xa_ex_1011.mdls | Riku (Wooden Sword) | 
+| xa_ex_1019.mdls | Riku (Wooden Sword) | 
+| xa_ex_1020.mdls | Kairi | 
+| xa_ex_1029.mdls | Kairi | 
+| xa_ex_1030.mdls | Leon | 
+| xa_ex_1031.mdls | Leon | 
+| xa_ex_1038.mdls | Leon | 
+| xa_ex_1039.mdls | Leon | 
+| xa_ex_1040.mdls | Yuffie | 
+| xa_ex_1041.mdls | Yuffie | 
+| xa_ex_1048.mdls | Yuffie | 
+| xa_ex_1049.mdls | Yuffie | 
+| xa_ex_1050.mdls | Mickey | 
+| xa_ex_1059.mdls | Mickey | 
+| xa_ex_1060.mdls | Pluto | 
+| xa_ex_1069.mdls | Pluto | 
+| xa_ex_1090.mdls | Maleficent  | 
+| xa_ex_1091.mdls | Maleficent  | 
+| xa_ex_1099.mdls | Maleficent  | 
+| xa_ex_1100.mdls | Fairy Godmother | 
+| xa_ex_1109.mdls | Fairy Godmother | 
+| xa_ex_1110.mdls | Huey | 
+| xa_ex_1119.mdls | Huey | 
+| xa_ex_1120.mdls | Dewey | 
+| xa_ex_1129.mdls | Dewey | 
+| xa_ex_1130.mdls | Louie | 
+| xa_ex_1139.mdls | Louie | 
+| xa_ex_1140.mdls | Arith | 
+| xa_ex_1148.mdls | Arith | 
+| xa_ex_1149.mdls | Arith | 
+| xa_ex_1150.mdls | Cloud | 
+| xa_ex_1151.mdls | Cloud | 
+| xa_ex_1159.mdls | Cloud | 
+| xa_ex_1160.mdls | Dark Riku | 
+| xa_ex_1168.mdls | Dark Riku | 
+| xa_ex_1200.mdls | Moogle | 
+| xa_ex_1209.mdls | Moogle | 
+| xa_ex_1210.mdls | Pongo (Dalmation) | 
+| xa_ex_1219.mdls | Pongo (Damation) | 
+| xa_ex_1220.mdls | Perdita (Dalmation) | 
+| xa_ex_1229.mdls | Perdita (Dalmation) | 
+| xa_ex_1230.mdls | Dalmation | 
+| xa_ex_1260.mdls | Dalmation | 
+| xa_ex_1269.mdls | Dalmation | 
+| xa_ex_1540.mdls | Cid | 
+| xa_ex_1549.mdls | Cid | 
+| xa_ex_1560.mdls | Riku (Soul Eater) | 
+| xa_ex_1568.mdls | Riku (Soul Eater) | 
+| xa_ex_1580.mdls | Ansem (Riku) | 
+| xa_ex_1588.mdls | Ansem (Riku) | 
+| xa_ex_1589.mdls | Ansem (Riku) | 
+| xa_ex_1590.mdls | Sora (Kid) | 
+| xa_ex_1600.mdls | Riku (Kid) | 
+| xa_ex_1610.mdls | Kairi (Kid) | 
+| xa_ex_1620.mdls | Kairi's | Grandma | 
+| xa_ex_1630.mdls | Ansem (w/Guardian) | 
+| xa_ex_1638.mdls | Ansem (w/Guardian) | 
+| xa_ex_1639.mdls | Ansem (w/Guardian) | 
+| xa_ex_1640.mdls | Ansem (Brown Coat) | 
+| xa_ex_1650.mdls | Donald (Angry) | 
+| xa_ex_2010.mdls | Heartless | Soldier | 
+| xa_ex_2019.mdls | Heartless | Soldier | 
+| xa_ex_2020.mdls | Heartless | Shadow | 
+| xa_ex_2021.mdls | Heartless | Shadow (Halloween Town) | 
+| xa_ex_2022.mdls | Heartless | Shadow (End of World?) | 
+| xa_ex_2029.mdls | Heartless | Shadow | 
+| xa_ex_2030.mdls | Heartless | Powerwilds | (Monkey) | 
+| xa_ex_2039.mdls | Heartless | Powerwilds | (Monkey) | 
+| xa_ex_2040.mdls | Heartless | Bouncywild (Monkey) | 
+| xa_ex_2049.mdls | Heartless | Bouncywild (Monkey) | 
+| xa_ex_2050.mdls | Heartless | Large Body | 
+| xa_ex_2059.mdls | Heartless | Large Body | 
+| xa_ex_2060.mdls | Heartless | Large Body (Agrabah) | 
+| xa_ex_2069.mdls | Heartless | Large Body (Agrabah) | 
+| xa_ex_2070.mdls | Heartless | Sea Neon | 
+| xa_ex_2079.mdls | Heartless | Sea Neon | 
+| xa_ex_2080.mdls | Heartless | Sea Neon | 
+| xa_ex_2089.mdls | Heartless | Sea Neon | 
+| xa_ex_2090.mdls | Heartless | Bandit | 
+| xa_ex_2099.mdls | Heartless | Bandit | 
+| xa_ex_2100.mdls | Heartless | Pirate  | 
+| xa_ex_2109.mdls | Heartless | Pirate  | 
+| xa_ex_2110.mdls | Heartless | Red Nocturne | 
+| xa_ex_2119.mdls | Heartless | Red Nocturne | 
+| xa_ex_2120.mdls | Heartless | Blue Rhapsody  | 
+| xa_ex_2129.mdls | Heartless | Blue Rhapsody  | 
+| xa_ex_2130.mdls | Heartless | Yellow Opera  | 
+| xa_ex_2139.mdls | Heartless | Yellow Opera  | 
+| xa_ex_2140.mdls | Heartless | Green Requiem | 
+| xa_ex_2149.mdls | Heartless | Green Requiem | 
+| xa_ex_2150.mdls | Heartless | Wizard | 
+| xa_ex_2151.mdls | Heartless | Wizard (Halloween Town) | 
+| xa_ex_2159.mdls | Heartless | Wizard | 
+| xa_ex_2160.mdls | Heartless | Air Soldier | 
+| xa_ex_2169.mdls | Heartless | Air Soldier | 
+| xa_ex_2170.mdls | Heartless | Pot Spider (Ligher Red) | 
+| xa_ex_2171.mdls | Red Pot (Hidden Pot Spider) | 
+| xa_ex_2172.mdls | Heartless | Pot Spider (Darker Red) | 
+| xa_ex_2179.mdls | Heartless | Pot Spider (Lighter Red) | 
+| xa_ex_2180.mdls | Heartless | Barrel Spider (Lighter Brown) | 
+| xa_ex_2181.mdls | Crate (Darker) (Hidden Barrel Spider) | 
+| xa_ex_2182.mdls | Heartless | Barrel Spider (Darker Brown) | 
+| xa_ex_2183.mdls | Crate (Lighter) (Hidden Barrel Spider) | 
+| xa_ex_2184.mdls | Heartless | Barrel Spider (Ligther Brown) | 
+| xa_ex_2189.mdls | Heartless | Barrel Spider (Even Lighter Brown? lol) | 
+| xa_ex_2190.mdls | Heartless | Pot Scorpion | 
+| xa_ex_2191.mdls | Red Pot (Hidden Pot Scorpion?) | 
+| xa_ex_2199.mdls | Heartless | Pot Scorpion | 
+| xa_ex_2200.mdls | Heartless | Wight Knight | 
+| xa_ex_2201.mdls | Heartless | Wight Knight (Halloween Town) | 
+| xa_ex_2209.mdls | Heartless | Wight Knight (Halloween Town) | 
+| xa_ex_2210.mdls | Heartless | Air Pirate  | 
+| xa_ex_2219.mdls | Heartless | Air Pirate | 
+| xa_ex_2220.mdls | Heartless | Gargoyle | 
+| xa_ex_2221.mdls | Heartless | Gargoyle (Halloween Town) | 
+| xa_ex_2229.mdls | Heartless | Gargoyle (Halloween Town) | 
+| xa_ex_2230.mdls | Heartless | Search Ghost  | 
+| xa_ex_2231.mdls | Heartless | Search Ghost (Halloween Town) | 
+| xa_ex_2238.mdls | Heartless | Search Ghost (Halloween Town) | 
+| xa_ex_2239.mdls | Heartless | Search Ghost  | 
+| xa_ex_2240.mdls | Heartless | Jet Balloon  | 
+| xa_ex_2249.mdls | Heartless | Jet Balloon | 
+| xa_ex_2250.mdls | Heartless | Missle Divers | 
+| xa_ex_2259.mdls | Heartless | Missle Divers | 
+| xa_ex_2260.mdls | Heartless | Chimera | 
+| xa_ex_2269.mdls | Heartless | Chimera | 
+| xa_ex_2270.mdls | Heartless | Battleship | 
+| xa_ex_2279.mdls | Heartless | Battleship | 
+| xa_ex_2280.mdls | Heartless | Darkball | 
+| xa_ex_2281.mdls | Heartless | Darkball (Halloween Town) | 
+| xa_ex_2282.mdls | Heartless | Darkball (End of World) | 
+| xa_ex_2289.mdls | Heartless | Darkball  | 
+| xa_ex_2290.mdls | Heartless | Invisible | 
+| xa_ex_2292.mdls | Heartless | Invisible (End of World) | 
+| xa_ex_2299.mdls | Heartless | Invisible | 
+| xa_ex_2310.mdls | Heartless | Behemoth | 
+| xa_ex_2311.mdls | Heartless | Behemoth (Different Color 1) | 
+| xa_ex_2312.mdls | Heartless | Behemoth (Different Color 2) | 
+| xa_ex_2317.mdls | Heartless | Behemoth (Different Color 2) | 
+| xa_ex_2318.mdls | Heartless | Behemoth (Different Color 1) | 
+| xa_ex_2319.mdls | Heartless | Behemoth | 
+| xa_ex_2320.mdls | Heartless | Wyvern | 
+| xa_ex_2329.mdls | Heartless | Wyvern | 
+| xa_ex_2330.mdls | Heartless | Angel Star | 
+| xa_ex_2339.mdls | Heartless | Angel Star | 
+| xa_ex_2340.mdls | Heartless | Defender | 
+| xa_ex_2349.mdls | Heartless | White Mushroom | 
+| xa_ex_2350.mdls | Heartless | White Mushroom (Halloween Town) | 
+| xa_ex_2352.mdls | Heartless | White Mushroom | 
+| xa_ex_2359.mdls | Heartless | White Mushroom | 
+| xa_ex_2380.mdls | Heartless | Black Fungi | 
+| xa_ex_2381.mdls | Heartless | Mushroom (Halloween Town) | 
+| xa_ex_2389.mdls | Heartless | Black Fungi | 
+| xa_ex_2390.mdls | Heartless | Rare Truffles | 
+| xa_ex_2391.mdls | Heartless | Rare Truffles | (Halloween Town) | 
+| xa_ex_2399.mdls | Heartless | Rare Truffles | 
+| xa_ex_2400.mdls | Heartless | Pot Centipede (Complete) | 
+| xa_ex_2410.mdls | Heartless | Pink Agaricus | 
+| xa_ex_2419.mdls | Heartless | Pink Agaricus | 
+| xa_ex_2420.mdls | Heartless | Neoshadow | 
+| xa_ex_2429.mdls | Heartless | Neoshadow | 
+| xa_ex_2430.mdls | Heartless | Soldier (Color 2) | 
+| xa_ex_2439.mdls | Heartless | Soldier (Color 2) | 
+| xa_ex_2440.mdls | Heartless | Shadow | 
+| xa_ex_2449.mdls | Heartless | Shadow | 
+| xa_ex_2450.mdls | Heartless | Sniperwild (Monkey) | 
+| xa_ex_2459.mdls | Heartless | Sniperwild (Monkey) | 
+| xa_ex_2460.mdls | Heartless | Black Ballade  | 
+| xa_ex_2469.mdls | Heartless | Black Ballade  | 
+| xa_ex_2470.mdls | Heartless | Search Ghost  | 
+| xa_ex_2479.mdls | Heartless | Search Ghost  | 
+| xa_ex_2480.mdls | Heartless | Jet Balloon  | 
+| xa_ex_2489.mdls | Heartless | Jet Balloon  | 
+| xa_ex_2490.mdls | Heartless | Missle Diver | 
+| xa_ex_3000.mdls | Sephiroth | 
+| xa_ex_3008.mdls | Sephiroth | 
+| xa_ex_3009.mdls | Sephiroth | 
+| xa_ex_3010.mdls | Xemnas | (Enigmatic Man) | 
+| xa_ex_3018.mdls | Xemnas | (Enigmatic Man) | 
+| xa_ex_3019.mdls | Xemnas | (Enigmatic Man) | 
+| xa_ex_4010.mdls | Hercules | 
+| xa_ex_4011.mdls | Hercules | 
+| xa_ex_4019.mdls | Hercules | 
+| xa_ex_4029.mdls | Dumbo | 
+| xa_ex_4030.mdls | Bambi | 
+| xa_ex_4039.mdls | Bambi | 
+| xa_ex_4040.mdls | Genie | 
+| xa_ex_4041.mdls | Genie | 
+| xa_ex_4042.mdls | Genie | 
+| xa_ex_4049.mdls | Genie | 
+| xa_ex_4050.mdls | Tinkerbell | 
+| xa_ex_4059.mdls | Tinkerbell | 
+| xa_ex_4060.mlds | Mushu | 
+| xa_ex_4069.mdls | Mushu | 
+| xa_ex_4070.mdls | Simba | 
+| xa_ex_4079.mdls | Simba | 
+| xa_ex_4098.mdls | Genie (With Legs) | 
+| xa_ex_7010.mdls | Sora (High-Poly) | 
+| xa_ex_7015.mdls | Sora (High-Poly) | 
+| xa_ex_7016.mdls | Sora (High-Poly) | 
+| xa_ex_7018.mdls | Sora (High-Poly) | 
+| xa_ex_7050.mdls | Sora (Atlantica) (High-Poly) | 
+| xa_ex_7070.mdls | Donald (Classic-outfit) (High-Poly) | 
+| xa_ex_7080.mdls | Donald (Wizard) (High-Poly) | 
+| xa_ex_7090.mdls | Donald (Atlantica) (High-Poly) | 
+| xa_ex_7100.mdls | Goofy (Classic-outfit) (High-Poly) | 
+| xa_ex_7110.mdls | Goofy (Knight) (High-Poly) | 
+| xa_ex_7140.mdls | Kairi (High-Poly) | 
+| xa_ex_7147.mdls | Kairi (High-Poly) | 
+| xa_ex_7148.mdls | Kairi (High-Poly) | 
+| xa_ex_7170.mdls | Maleficent (High-Poly) | 
+| xa_ex_7178.mdls | Maleficent (High-Poly) | 
+| xa_ex_7190.mdls | Riku (Wooden Sword) (High-Poly) | 
+| xa_ex_7210.mdls | Ansem (Riku) (High-Poly) | 
+| xa_ex_7215.mdls | Ansem (Riku) (High-Poly) | 
+| xa_ex_7216.mdls | Ansem (Riku) (High-Poly) | 
+| xa_ex_7218.mdls | Ansem (Riku) (High-Poly) | 
+| xa_ex_7228.mdls | Ansem (High-Poly) | 
+| xa_ex_7230.mdls | Donald (High-Poly) | 
+| xa_ex_7240.mdls | Goofy (High-Poly) | 
+| xa_he_1000.mdls | Phil | 
+| xa_he_1009.mdls | Phil | 
+| xa_he_1010.mdls | Hades | 
+| xa_he_1011.mdls | Hades | 
+| xa_he_1019.mdls | Hades | 
+| xa_he_1030.mdls | Hades | (Sephiroth Feather) | 
+| xa_he_1040.mdls | Unknown Object | 
+| xa_he_3000.mdls | Rock Titan | 
+| xa_he_3009.mdls | Rock Titan | 
+| xa_he_3010.mdls | Ice Titan | 
+| xa_he_3019.mdls | Ice Titan | 
+| xa_he_3020.mdls | Cerberus | 
+| xa_he_3021.mdls | Cerberus | 
+| xa_he_3029.mdls | Cerberus | 
+| xa_eh_7000.mdls | Hades | (High-Poly) | 
+| xa_lm_0000.mdls | Sora (Atlantica) | 
+| xa_lm_0010.mdls | Donald (Atlantica) | 
+| xa_lm_0020.mdls | Goofy (Atlantica) | 
+| xa_lm_0030.mdls | Aerial | 
+| xa_lm_0039.mdls | Aerial | 
+| xa_lm_1000.mdls | King Triton | 
+| xa_lm_1009.mdls | King Triton | 
+| xa_lm_1010.mdls | Sebastian | 
+| xa_lm_1019.mdls | Sebastian | 
+| xa_lm_1020.mdls | Flounder | 
+| xa_lm_1029.mdls | Flounder | 
+| xa_lm_1040.mdls | Fish | 
+| xa_lm_1050.mdls | Ursula | 
+| xa_lm_1059.mdls | Ursula | 
+| xa_lm_3000.mdls | Ursula Big (Boss) | 
+| xa_lm_3010.mdls | Flotsam / Jetsam | 
+| xa_lm_3020.mdls | Flotsam / Jetsam | 
+| xa_lm_3029.mdls | Flotsam / Jetsam | 
+| xa_lm_3030.mdls | Shark | 
+| xa_lm_3040.mdls | Ursula Big (Tenticles) (Boss) | 
+| xa_lm_7000.mdls | Ariel (High-Poly) | 
+| xa_lm_7010.mdls | King Triton (High-Poly) | 
+| xa_lm_7020.mdls | Ursula (High-Poly) | 
+| xa_nm_0000.mdls | Sora (Halloween Town) | 
+| xa_nm_0010.mdls | Donald (Halloween Town) | 
+| xa_nm_0018.mdls | Donald (Halloween Town) | 
+| xa_nm_0020.mdls | Goofy (Halloween Town) | 
+| xa_nm_0028.mdls | Goofy (Halloween Town) | 
+| xa_nm_0030.mdls | Jack Skellington | 
+| xa_nm_0031.mdls | Jack Skellington | 
+| xa_nm_0038.mdls | Jack Skellington | 
+| xa_nm_0039.mdls | Jack Skellington | 
+| xa_nm_1000.mdls | Sally | 
+| xa_nm_1008.mdls | Sally | 
+| xa_nm_1009.mdls | Sally | 
+| xa_nm_1010.mdls | Zero | 
+| xa_nm_1019.mdls | Zero | 
+| xa_nm_1028.mdls | Dr. Finkelstein | 
+| xa_nm_1029.mdls | Dr. Finkelstein | 
+| xa_nm_1030.mdls | Lock  | 
+| xa_nm_1031.mdls | Lock  | 
+| xa_nm_1038.mdls | Lock  | 
+| xa_nm_1039.mdls | Lock  | 
+| xa_nm_1040.mdls | Shock | 
+| xa_nm_1041.mdls | Shock | 
+| xa_nm_1048.mdls | Shock | 
+| xa_nm_1049.mdls | Shock | 
+| xa_nm_1050.mdls | Barrel | 
+| xa_nm_1051.mdls | Barrel | 
+| xa_nm_1058.mdls | Barrel | 
+| xa_nm_1059.mdls | Barrel | 
+| xa_nm_1060.mdls | Mayor of Halloween Town | 
+| xa_nm_1068.mdls | Mayor of Halloween Town | 
+| xa_nm_1069.mdls | Mayor of Halloween Town | 
+| xa_nm_1090.mdls | Ghost Prop? | 
+| xa_nm_3000.mdls | Oogie Boogie | 
+| xa_nm_3008.mdls | Oogie Boogie | 
+| xa_nm_3009.mdls | Oogie Boogie | 
+| xa_nm_3010.mdls | Oogie Boogie (Boss | from Manor) | 
+| xa_nm_3020.mdls | Oogie Boogie Piece (Boss | from Manor?) | 
+| xa_nm_3030.mdls | Oogie Boogie Piece (Boss | from Manor?) | 
+| xa_nm_7000.mdls | Jack Skellington (High-Poly) | 
+| xa_nm_7010.mdls | Ooogie Boogie (High-Poly) (Dice in hands) | 
+| xa_pc_0000.mdls | The Beast | 
+| xa_pc_0005.mdls | The Beast | 
+| xa_pc_0006.mdls | The Beast | 
+| xa_pc_0007.mdls | The Beast | 
+| xa_pc_0008.mdls | The Beast | 
+| xa_pc_0009.mdls | The Beast | 
+| xa_pc_1000.mdls | Belle | 
+| xa_pc_1008.mdls | Belle | 
+| xa_pc_1009.mdls | Belle | 
+| xa_pc_1010.mdls | Aurora | 
+| xa_pc_1018.mdls | Aurora | 
+| xa_pc_1019.mdls | Alice | 
+| xa_pc_1020.mdls | Alice | 
+| xa_pc_1028.mdls | Alice | 
+| xa_pc_1029.mdls | Alice | 
+| xa_pc_1030.mdls | Cinderella | 
+| xa_pc_1038.mdls | Cinderella | 
+| xa_pc_1039.mdls | Cinderella | 
+| xa_pc_1040.mdls | Snow White | 
+| xa_pc_1048.mdls | Snow White | 
+| xa_pc_1049.mdls | Snow White | 
+| xa_pc_3000.mdls | Maleficent (Dragon) | 
+| xa_pc_3009.mdls | Maleficent (Dragon) | 
+| xa_pc_3020.mdls | Chernabog | 
+| xa_pi_1000.mdls | Pinocchio | 
+| xa_pi_1008.mdls | Pinocchio | 
+| xa_pi_1009.mdls | Pinocchio | 
+| xa_pi_1010.mdls | Geppetto | 
+| xa_pi_1019.mdls | Geppetto | 
+| xa_pi_1020.mdls | Pinocchio (Human) | 
+| xa_pi_3000.mdls | Parasite Cage | 
+| xa_pi_3009.mdls | Parasite Cage | 
+| xa_pi_7000.mdls | Pinocchio (High-Poly) | 
+| xa_po_0000.mdls | Pooh Bear | 
+| xa_po_0009.mdls | Pooh Bear | 
+| xa_po_1000.mdls | Tigger | 
+| xa_po_1009.mdls | Tigger | 
+| xa_po_1010.mdls | Piglet | 
+| xa_po_1019.mdls | Piglet | 
+| xa_po_1020.mdls | Eeyore | 
+| xa_po_1029.mdls | Eeyore | 
+| xa_po_1030.mdls | Rabbit | 
+| xa_po_1039.mdls | Rabbit | 
+| xa_po_1040.mdls | Owl | 
+| xa_po_1049.mdls | Owl  | 
+| xa_po_1050.mdls | Roo | 
+| xa_po_1059.mdls | Roo | 
+| xa_po_7000.mdls | Pooh Beart (High-Poly) | 
+| xa_pp_0000.mdls | Peter Pan | 
+| xa_pp_0008.mdls | Peter Pan | 
+| xa_pp_0009.mdls | Peter Pan | 
+| xa_pp_1010.mdls | Wendy | 
+| xa_pp_1019.mdls | Wendy | 
+| xa_pp_1020.mdls | Smee | 
+| xa_pp_1029.mdls | Smee | 
+| xa_pp_1040.mdls | Crocodile | 
+| xa_pp_1049.mdls | Crocodile | 
+| xa_pp_3000.mdls | Captain Hook | 
+| xa_pp_3001.mdls | Captain Hook | 
+| xa_pp_3009.mdls | Captain Hook | 
+| xa_pp_3010.mdls | Phantom | 
+| xa_pp_3019.mdls | Phantom | 
+| xa_pp_3020.mdls | Shadow Sora | 
+| xa_pp_3030.mdls | Shadow Sora (With Keyblade) | 
+| xa_pp_7000.mdls | Peter Pan (High-Poly) | 
+| xa_pp_7008.mdls | Peter Pan (High-Poly) | 
+| xa_pp_7010.mdls | Captain Hook (High-Poly) | 
+| xa_tw_1000.mdls | Traverse Town NPC / Shopkeeper | 
+| xa_tw_1010.mdls | Traverse Town NPC  | 
+| xa_tw_1030.mdls | Traverse Town NPC  | 
+| xa_tw_1040.mdls | Traverse Town NPC  | 
+| xa_tw_1050.mdls | Merlin | 
+| xa_tw_1059.mdls | Merlin | 
+| xa_tw_1060.mdls | Kairi Good Luck Charm | 
+| xa_tw_2010.mdls | Magic Chair | 
+| xa_tw_2020.mdls | Magic Table | 
+| xa_tw_2030.mdls | Magic Dresser | 
+| xa_tw_2040.mdls | Magic Teapot | 
+| xa_tw_3000.mdls | Heartless | Guard Armor | 
+| xa_tw_3009.mdls | Heartless | Guard Armor | 
+| xa_tw_3010.mdls | Heartless | Guard Armor | 
+| xa_tw_3019.mdls | Heartless | Guard Armor | 
+| xa_tw_3020.mdls | Heartless | Guard Armor (Pink) | 
+| xa_tw_3029.mdls | Heartless | Guard Armor (Pink) | 
+| xa_tz_0030.mdls | Tarzan | 
+| xa_tz_0039.mdls | Tarzan | 
+| xa_tz_1000.mdls | Jane | 
+| xa_tz_1009.mdls | Jane | 
+| xa_tz_1010.mdls | Terk | 
+| xa_tz_1019.mdls | Terk | 
+| xa_tz_1030.mdls | Kala | 
+| xa_tz_1039.mdls | Kala | 
+| xa_tz_1040.mdls | Kerjack | 
+| xa_tz_1049.mdls | Kerjack | 
+| xa_tz_1050.mdls | NPC Gorilla | 
+| xa_tz_3000.mdls | Sabor | 
+| xa_tz_3009.mdls | Sabor | 
+| xa_tz_3010.mdls | Clayton | 
+| xa_tz_3011.mdls | Clayton | 
+| xa_tz_3019.mdls | Clayton | 
+| xa_tz_3020.mdls | Clayton and Stealth Sneak (Chameleon) | 
+| xa_tz_3029.mdls | Clayton and Stealth Sneak (Chameleon) | 
+| xa_tz_3040.mdls | Clayton and Stealth Sneak (Chameleon) (Black) | 
+| xa_tz_3049.mdls | Clayton and Stealth Sneak (Chameleon) (Black) | 
+| xa_tz_7000.mdls | Tarzan (High-Poly) | 
+| xa_tz_7010.mdls | Clayton (High-Poly) | 

--- a/docs/kh1/index.md
+++ b/docs/kh1/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts I
+# Kingdom Hearts I - Back to [Index](../index.md)
 
 ## General Documentation
 
@@ -6,3 +6,6 @@
 * [Worlds](worlds.md)
 * [File Types](file-type.md)
 
+## Dictionaries
+
+  * [Mdls](dictionary/mdls.md)

--- a/docs/kh2/dictionary/obj.md
+++ b/docs/kh2/dictionary/obj.md
@@ -1,8 +1,8 @@
 # [Kingdom Hearts II](index.md) - Objects (Entities)
 
-| Id       |   Filename    | obj (Entity)
-|------------|---------------|---------------|
-1 | M_EX060 | (M) Fat Bandit |
+| Id       |   Filename    | obj (Entity) |
+|----------|---------------|--------------|
+| 1 | M_EX060 | (M) Fat Bandit |
 | 2 | M_EX500 | (M) Trick Ghost |
 | 3 | M_EX510 | (M) Rabid Dog |
 | 4 | M_EX520 | (M) Hook Bat |

--- a/docs/kh2/index.md
+++ b/docs/kh2/index.md
@@ -1,6 +1,6 @@
-# Kingdom Hearts II
+# Kingdom Hearts II - Back to [Index](../index.md)
 
-## General documentation
+## General Documentation
 
 * [Games builds](builds.md)
 * [Editions](editions.md)

--- a/docs/kh3/index.md
+++ b/docs/kh3/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts III
+# Kingdom Hearts III - Back to [Index](../index.md)
 
 ## General documentation
 

--- a/docs/khds/common/index.md
+++ b/docs/khds/common/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts DS games
+# Kingdom Hearts DS games - Back to [Index](../../index.md)
 
 ## General Documentation
 

--- a/docs/khds/days/index.md
+++ b/docs/khds/days/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts 358/2 Days
+# Kingdom Hearts 358/2 Days - Back to [Index](../../index.md)
 
 ## General Documentation
 

--- a/docs/khds/recoded/index.md
+++ b/docs/khds/recoded/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts Re:Coded
+# Kingdom Hearts Re:Coded - Back to [Index](../../index.md)
 
 ## General Documentation
 

--- a/docs/mom/index.md
+++ b/docs/mom/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts Melody of Memory
+# Kingdom Hearts Melody of Memory - Back to [Index](../index.md)
 
 ## Notes
 

--- a/docs/other/coded/index.md
+++ b/docs/other/coded/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts Coded
+# Kingdom Hearts Coded - Back to [Index](../../index.md)
 
 ## General Documentation
 

--- a/docs/other/vcast/index.md
+++ b/docs/other/vcast/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts V-Cast
+# Kingdom Hearts V-Cast - Back to [Index](../../index.md)
 
 ## General Documentation
 

--- a/docs/other/vr/index.md
+++ b/docs/other/vr/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts VR
+# Kingdom Hearts VR - Back to [Index](../../index.md)
 
 ## General Documentation
 

--- a/docs/recom/index.md
+++ b/docs/recom/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts Re:Chain of Memories
+# Kingdom Hearts Re:Chain of Memories - Back to [Index](../index.md)
 
 ## General Documentation
 

--- a/docs/remasters/15plus25/index.md
+++ b/docs/remasters/15plus25/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts HD 1.5 + 2.5 ReMIX
+# Kingdom Hearts HD 1.5 + 2.5 ReMIX - Back to [Index](../../index.md)
 
 ## General documentation
 

--- a/docs/remasters/28fcp/index.md
+++ b/docs/remasters/28fcp/index.md
@@ -1,4 +1,4 @@
-# Kingdom Hearts HD 2.8 Final Chapter Prologue
+# Kingdom Hearts HD 2.8 Final Chapter Prologue - Back to [Index](../../index.md)
 
 ## General documentation
 

--- a/docs/tool/index.md
+++ b/docs/tool/index.md
@@ -1,4 +1,4 @@
-# OpenKH tools
+# OpenKH tools - Back to [Index](../index.md)
 
 As a preface before tools are listed, it is important to note that different tools will be marked as either "CLI.ToolName" or "GUI.ToolName". This is to distinguish whether a specific program uses the command line or terminal or a GUI. The primary difference between the two is one involves typing commands into a terminal while the other has fancy clickable buttons.
 If you have never used the command line before or have used it very little, fear not, for instructions for those tools will be equally as thorough as GUI instructions!


### PR DESCRIPTION
In addition to adding the KH1 MDLS dictionary (courtesy of Rapid), I have finally added a sane way to go to the previous page on every single sub-index. I.e., going to the KH2 main index page will include a "Back to Index" link at the top. Sub-pages should include the same thing via clicking the game title at the top of each page as well, though I suppose it may be possible I missed some. Nevertheless, hopefully this improves navigation a fair bit.

Edit: Forgot to mention, I updated the `NOTICE` file, as well as the `docs/_config.yml` file too.