### PR TITLE
Custom HD Asset Support

### DIFF
--- a/OpenKh.Egs/EgsHdAsset.cs
+++ b/OpenKh.Egs/EgsHdAsset.cs
@@ -24,7 +24,7 @@ namespace OpenKh.Egs
             [Data(Count = 0x20)] public string Name { get; set; }
             // The offset is relative to: Original asset's header size + all remastered asset's header size + original asset's decompressed data length
             [Data] public int Offset { get; set; }
-            [Data] public int Unknown24 { get; set; }
+            [Data] public int OriginalAssetOffset { get; set; }
             [Data] public int DecompressedLength { get; set; }
             [Data] public int CompressedLength { get; set; }
         }
@@ -61,6 +61,15 @@ namespace OpenKh.Egs
         public byte[] OriginalRawData => _originalRawData;
         public Dictionary<string, byte[]> RemasteredAssetsDecompressedData => _remasteredAssetsData;
         public Dictionary<string, byte[]> RemasteredAssetsCompressedData => _remasteredAssetsRawData;
+
+        public EgsHdAsset(Header temp_header, byte[] temp_originalData, byte[] temp_originalRawData, byte[] temp_seed)
+        {
+            _header = temp_header;
+            _originalData = temp_originalData;
+            _originalRawData = temp_originalRawData;
+            _seed = temp_seed;
+            _entries = new Dictionary<string, RemasteredEntry>();
+        }
 
         public EgsHdAsset(Stream stream)
         {

--- a/OpenKh.Egs/EgsTools.cs
+++ b/OpenKh.Egs/EgsTools.cs
@@ -540,6 +540,9 @@ namespace OpenKh.Egs
                 case (".imd", true):
                     asset = new IMD(originalAssetData);
                     break;
+                case (".imz", true):
+                    asset = new IMZ(originalAssetData);
+                    break;
                 case (".mdlx", true):
                     asset = new MDLX(originalAssetData);
                     break;
@@ -600,7 +603,7 @@ namespace OpenKh.Egs
 
                 for (int i = 0; i < TextureCount; i++)
 				{
-					ms.seek(0x10 + (i * 0x8), SeekOrigin.Begin);
+					ms.Seek(0x10 + (i * 0x8), SeekOrigin.Begin);
 					int offset = ms.ReadInt32();
 					ms.Seek(offset, SeekOrigin.Begin);
 					int magic2 = ms.ReadInt32();
@@ -609,7 +612,7 @@ namespace OpenKh.Egs
 						Invalid = true;
 						return;
 					}
-						
+
 					ms.ReadInt32(); //always 256
 					int IMDoffset = ms.ReadInt32(); //offset for image data
 					Offsets.Add(offset + IMDoffset + 0x20000000);
@@ -626,13 +629,11 @@ namespace OpenKh.Egs
 
         public BAR(byte[] originalAssetData)
         {
-
             using (MemoryStream ms = new MemoryStream(originalAssetData))
             {
                 int magic = ms.ReadInt32();
                 if (magic != 22167874)
                 { //BAR
-                    Console.WriteLine("Invalid BAR! - " + magic);
                     Invalid = true;
                     return;
                 }
@@ -655,10 +656,10 @@ namespace OpenKh.Egs
 							int magic2 = ms.ReadInt32();
 							if (magic2 == 1145523529)
 							{ //IMGD
-								TextureCount = 1;
+								TextureCount += 1;
 								ms.ReadInt32(); //always 256
 								int IMDoffset = ms.ReadInt32(); //offset for image data
-								Offsets.Add((IMDoffset + offset)+ 0x20000000);
+								Offsets.Add(offset + IMDoffset + 0x20000000);
 							}
 							break;
 						case (29): //IMZ
@@ -668,16 +669,17 @@ namespace OpenKh.Egs
 							ms.Seek(offset, SeekOrigin.Begin);
 
 							int magic2 = ms.ReadInt32();
-							if (magic2 != 1514622281)
+							if (magic2 == 1514622281)
 							{ //IMGZ
 								ms.ReadInt32();
 								ms.ReadInt32();
 								int ImageCount = ms.ReadInt32();
+                                TextureCount += ImageCount;
 								for (int j = 0; j < ImageCount; j++)
 								{
-									ms.seek(0x10 + (j * 0x8), SeekOrigin.Begin);
+									ms.Seek(offset + 0x10 + (j * 0x8), SeekOrigin.Begin);
 									int IMZoffset = ms.ReadInt32();
-									ms.Seek(IMZoffset, SeekOrigin.Begin);
+									ms.Seek(offset + IMZoffset, SeekOrigin.Begin);
 									
 									int magic3 = ms.ReadInt32();
 									if (magic3 == 1145523529)
@@ -694,13 +696,13 @@ namespace OpenKh.Egs
 
                 if (TextureCount == 0)
                 {
-                    Console.WriteLine("BAR doesn't contain any images." );
-                    Invalid = true;
-                    return;
+					Console.WriteLine("BAR doesn't contain any images." );
+					Invalid = true;
+					return;
                 }
-            }
-        }
-    }
+			}
+		}
+	}
 
     class MDLX
     {

--- a/OpenKh.Egs/EgsTools.cs
+++ b/OpenKh.Egs/EgsTools.cs
@@ -185,7 +185,7 @@ namespace OpenKh.Egs
             foreach (var filename in patchFiles)
             {
                 AddFile(inputFolder, filename, patchedHedStream, patchedPkgStream);
-                Console.WriteLine($"Added a new file: {filename}");
+                //Console.WriteLine($"Added a new file: {filename}");
             }
         }
 
@@ -580,8 +580,8 @@ namespace OpenKh.Egs
             }
         }
     }
-	
-	class IMZ
+
+    class IMZ
     {
         public List<int> Offsets = new List<int>();
         public int TextureCount = 0;
@@ -599,24 +599,24 @@ namespace OpenKh.Egs
                 }
                 ms.ReadInt32();
                 ms.ReadInt32();
-				TextureCount = ms.ReadInt32();
+                TextureCount = ms.ReadInt32();
 
                 for (int i = 0; i < TextureCount; i++)
-				{
-					ms.Seek(0x10 + (i * 0x8), SeekOrigin.Begin);
-					int offset = ms.ReadInt32();
-					ms.Seek(offset, SeekOrigin.Begin);
-					int magic2 = ms.ReadInt32();
-					if (magic2 != 1145523529)
-					{ //IMGD
-						Invalid = true;
-						return;
-					}
+                {
+                    ms.Seek(0x10 + (i * 0x8), SeekOrigin.Begin);
+                    int offset = ms.ReadInt32();
+                    ms.Seek(offset, SeekOrigin.Begin);
+                    int magic2 = ms.ReadInt32();
+                    if (magic2 != 1145523529)
+                    { //IMGD
+                        Invalid = true;
+                        return;
+                    }
 
-					ms.ReadInt32(); //always 256
-					int IMDoffset = ms.ReadInt32(); //offset for image data
-					Offsets.Add(offset + IMDoffset + 0x20000000);
-				}
+                    ms.ReadInt32(); //always 256
+                    int IMDoffset = ms.ReadInt32(); //offset for image data
+                    Offsets.Add(offset + IMDoffset + 0x20000000);
+                }
             }
         }
     }
@@ -639,70 +639,72 @@ namespace OpenKh.Egs
                 }
 
                 int count = ms.ReadInt32();
+                int offset = 0;
+                int magic2 = 0;
 
                 for (int i = 0; i < count; i++)
                 {
                     //Console.WriteLine("Testing number: " + i);
                     ms.Seek(0x10 + (i * 0x10), SeekOrigin.Begin);
                     int type = ms.ReadInt32();
-					switch (type)
-					{
-						case (24): //IMD
-							//Console.WriteLine("is an image! - " + type);
-							ms.ReadInt32();
-							int offset = ms.ReadInt32();
-							ms.Seek(offset, SeekOrigin.Begin);
+                    switch (type)
+                    {
+                        case (24): //IMD
+                                   //Console.WriteLine("is an image! - " + type);
+                            ms.ReadInt32();
+                            offset = ms.ReadInt32();
+                            ms.Seek(offset, SeekOrigin.Begin);
 
-							int magic2 = ms.ReadInt32();
-							if (magic2 == 1145523529)
-							{ //IMGD
-								TextureCount += 1;
-								ms.ReadInt32(); //always 256
-								int IMDoffset = ms.ReadInt32(); //offset for image data
-								Offsets.Add(offset + IMDoffset + 0x20000000);
-							}
-							break;
-						case (29): //IMZ
-							//Console.WriteLine("is an image collection! - " + type);
-							ms.ReadInt32();
-							int offset = ms.ReadInt32();
-							ms.Seek(offset, SeekOrigin.Begin);
+                            magic2 = ms.ReadInt32();
+                            if (magic2 == 1145523529)
+                            { //IMGD
+                                TextureCount += 1;
+                                ms.ReadInt32(); //always 256
+                                int IMDoffset = ms.ReadInt32(); //offset for image data
+                                Offsets.Add(offset + IMDoffset + 0x20000000);
+                            }
+                            break;
+                        case (29): //IMZ
+                                   //Console.WriteLine("is an image collection! - " + type);
+                            ms.ReadInt32();
+                            offset = ms.ReadInt32();
+                            ms.Seek(offset, SeekOrigin.Begin);
 
-							int magic2 = ms.ReadInt32();
-							if (magic2 == 1514622281)
-							{ //IMGZ
-								ms.ReadInt32();
-								ms.ReadInt32();
-								int ImageCount = ms.ReadInt32();
+                            magic2 = ms.ReadInt32();
+                            if (magic2 == 1514622281)
+                            { //IMGZ
+                                ms.ReadInt32();
+                                ms.ReadInt32();
+                                int ImageCount = ms.ReadInt32();
                                 TextureCount += ImageCount;
-								for (int j = 0; j < ImageCount; j++)
-								{
-									ms.Seek(offset + 0x10 + (j * 0x8), SeekOrigin.Begin);
-									int IMZoffset = ms.ReadInt32();
-									ms.Seek(offset + IMZoffset, SeekOrigin.Begin);
-									
-									int magic3 = ms.ReadInt32();
-									if (magic3 == 1145523529)
-									{
-										ms.ReadInt32(); //always 256
-										int IMDoffset = ms.ReadInt32(); //offset for image data
-										Offsets.Add(offset + IMZoffset + IMDoffset + 0x20000000);
-									}
-								}
-							}
-							break;
-					}
+                                for (int j = 0; j < ImageCount; j++)
+                                {
+                                    ms.Seek(offset + 0x10 + (j * 0x8), SeekOrigin.Begin);
+                                    int IMZoffset = ms.ReadInt32();
+                                    ms.Seek(offset + IMZoffset, SeekOrigin.Begin);
+
+                                    int magic3 = ms.ReadInt32();
+                                    if (magic3 == 1145523529)
+                                    {
+                                        ms.ReadInt32(); //always 256
+                                        int IMDoffset = ms.ReadInt32(); //offset for image data
+                                        Offsets.Add(offset + IMZoffset + IMDoffset + 0x20000000);
+                                    }
+                                }
+                            }
+                            break;
+                    }
                 }
 
                 if (TextureCount == 0)
                 {
-					Console.WriteLine("BAR doesn't contain any images." );
-					Invalid = true;
-					return;
+                    Console.WriteLine("BAR doesn't contain any images.");
+                    Invalid = true;
+                    return;
                 }
-			}
-		}
-	}
+            }
+        }
+    }
 
     class MDLX
     {

--- a/OpenKh.Egs/Helpers.cs
+++ b/OpenKh.Egs/Helpers.cs
@@ -103,6 +103,30 @@ namespace OpenKh.Egs
         {
             return filePath.Replace($"{origin}\\", "").Replace(@"\", "/");
         }
+        public static int IndexOfByteArray(byte[] a, byte[] b, int s = 0)
+        {
+            int index = Array.IndexOf(a, b[0], s);
+            while (index > -1)
+            {
+                if (index > -1)
+                {
+                    bool match = true;
+                    for (int i = 1; i < b.Length; i++)
+                    {
+                        if (index + i > a.Length)
+                            match = false;
+                        if (a[index + i] != b[i])
+                            match = false;
+                        if (!match)
+                            break;
+                    }
+                    if (match)
+                        return index;
+                }
+                index = Array.IndexOf(a, b[0], index + 1);
+            }
+            return -1;
+        }
 
         #endregion
     }

--- a/OpenKh.Egs/Helpers.cs
+++ b/OpenKh.Egs/Helpers.cs
@@ -103,27 +103,30 @@ namespace OpenKh.Egs
         {
             return filePath.Replace($"{origin}\\", "").Replace(@"\", "/");
         }
+
         public static int IndexOfByteArray(byte[] a, byte[] b, int s = 0)
         {
             int index = Array.IndexOf(a, b[0], s);
             while (index > -1)
             {
-                bool match = true;
-                for (int i = 1; i < b.Length; i++)
+                if (index > -1)
                 {
-                    if (index + i > a.Length || a[index + i] != b[i])
-					{
-                        match = false;
-						break
-					}
+                    bool match = true;
+                    for (int i = 1; i < b.Length; i++)
+                    {
+                        if (index + i > a.Length || a[index + i] != b[i])
+						{
+                            match = false;
+                            break;
+						}
+                    }
+                    if (match)
+                        return index;
                 }
-                if (match)
-                    return index;
                 index = Array.IndexOf(a, b[0], index + 1);
             }
             return -1;
         }
-
         #endregion
     }
 }

--- a/OpenKh.Egs/Helpers.cs
+++ b/OpenKh.Egs/Helpers.cs
@@ -108,21 +108,17 @@ namespace OpenKh.Egs
             int index = Array.IndexOf(a, b[0], s);
             while (index > -1)
             {
-                if (index > -1)
+                bool match = true;
+                for (int i = 1; i < b.Length; i++)
                 {
-                    bool match = true;
-                    for (int i = 1; i < b.Length; i++)
-                    {
-                        if (index + i > a.Length)
-                            match = false;
-                        if (a[index + i] != b[i])
-                            match = false;
-                        if (!match)
-                            break;
-                    }
-                    if (match)
-                        return index;
+                    if (index + i > a.Length || a[index + i] != b[i])
+					{
+                        match = false;
+						break
+					}
                 }
+                if (match)
+                    return index;
                 index = Array.IndexOf(a, b[0], index + 1);
             }
             return -1;


### PR DESCRIPTION
Based on [KH PC Patch Manager](https://github.com/AntonioDePau/KHPCPatchManager) and also worked on by DA, this allows KH2.IdxImg to include custom HD assets for most filetypes when repacking.

Supported filetypes include mdlx, imd, imz, or the latter two within a bar file. Some files are not supported such as a.fm, map, or any bar file containing a pax subfile.