### PR TITLE
Some code cleanup and fixes for HD linking.

### DIFF
--- a/OpenKh.Egs/EgsTools.cs
+++ b/OpenKh.Egs/EgsTools.cs
@@ -645,6 +645,7 @@ namespace OpenKh.Egs
                 case (".bar", true):
                 case (".bin", true):
                 case (".mag", true):
+                //case (".map", true): //alot more complicated than i thought. try again later
                 case (".mdlx", true):
                     asset = new BAR(originalAssetData);
                     break;
@@ -892,7 +893,7 @@ namespace OpenKh.Egs
                             //Console.WriteLine("RAW image!");
                             ms.Seek(offset, SeekOrigin.Begin);
                             subfile = ms.ReadBytes(subsize);
-                            subasset = new RAW(subfile, offset, subname);
+                            subasset = new RAW(subfile, offset);
 
                             TextureCount += subasset.TextureCount;
                             OffsetsTIM.AddRange(subasset.Offsets);


### PR DESCRIPTION
Some refactoring that removes a lot of redundancy in the code was done for the file classes.
In addition, offsets for RAW textures that use Pixel Storage Modes other than 8bpp should now be correct.
I'm not aware of any MDLX that uses a PSM other than 8bpp, but this was needed for *.map HD linking at least once I finally figure that out.

Sorry if I've been putting out quite a few PRs about this stuff btw.