### PR TITLE
upgrade .Net version to 6.0

### DIFF
--- a/IteEditor/OpenKh.Tools.IteViewer.csproj
+++ b/IteEditor/OpenKh.Tools.IteViewer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/OpenKh.Bbs/OpenKh.Bbs.csproj
+++ b/OpenKh.Bbs/OpenKh.Bbs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/OpenKh.Command.Arc/OpenKh.Command.Arc.csproj
+++ b/OpenKh.Command.Arc/OpenKh.Command.Arc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.Bar/OpenKh.Command.Bar.csproj
+++ b/OpenKh.Command.Bar/OpenKh.Command.Bar.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.Bbsa/OpenKh.Command.Bbsa.csproj
+++ b/OpenKh.Command.Bbsa/OpenKh.Command.Bbsa.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.CoctChanger/OpenKh.Command.CoctChanger.csproj
+++ b/OpenKh.Command.CoctChanger/OpenKh.Command.CoctChanger.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.DoctChanger/OpenKh.Command.DoctChanger.csproj
+++ b/OpenKh.Command.DoctChanger/OpenKh.Command.DoctChanger.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.HdAssets/OpenKh.Command.HdAssets.csproj
+++ b/OpenKh.Command.HdAssets/OpenKh.Command.HdAssets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.IdxImg/OpenKh.Command.IdxImg.csproj
+++ b/OpenKh.Command.IdxImg/OpenKh.Command.IdxImg.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.ImgTool/OpenKh.Command.ImgTool.csproj
+++ b/OpenKh.Command.ImgTool/OpenKh.Command.ImgTool.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.Layout/OpenKh.Command.Layout.csproj
+++ b/OpenKh.Command.Layout/OpenKh.Command.Layout.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.MapGen/OpenKh.Command.MapGen.csproj
+++ b/OpenKh.Command.MapGen/OpenKh.Command.MapGen.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.MsgTool/OpenKh.Command.MsgTool.csproj
+++ b/OpenKh.Command.MsgTool/OpenKh.Command.MsgTool.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.PAMtoFBXConverter/OpenKh.Command.PAMtoFBXConverter.csproj
+++ b/OpenKh.Command.PAMtoFBXConverter/OpenKh.Command.PAMtoFBXConverter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.PmoConverter/OpenKh.Command.PmoConverter.csproj
+++ b/OpenKh.Command.PmoConverter/OpenKh.Command.PmoConverter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.PmpConverter/OpenKh.Command.PmpConverter.csproj
+++ b/OpenKh.Command.PmpConverter/OpenKh.Command.PmpConverter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.Rbin/OpenKh.Command.Rbin.csproj
+++ b/OpenKh.Command.Rbin/OpenKh.Command.Rbin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.Command.SpawnScript/OpenKh.Command.SpawnScript.csproj
+++ b/OpenKh.Command.SpawnScript/OpenKh.Command.SpawnScript.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Command.TexFooter/OpenKh.Command.TexFooter.csproj
+++ b/OpenKh.Command.TexFooter/OpenKh.Command.TexFooter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/OpenKh.Common/OpenKh.Common.csproj
+++ b/OpenKh.Common/OpenKh.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
       <LangVersion>latest</LangVersion>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/OpenKh.Ddd/OpenKh.Ddd.csproj
+++ b/OpenKh.Ddd/OpenKh.Ddd.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.Egs/OpenKh.Egs.csproj
+++ b/OpenKh.Egs/OpenKh.Egs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.Engine.MonoGame/OpenKh.Engine.MonoGame.csproj
+++ b/OpenKh.Engine.MonoGame/OpenKh.Engine.MonoGame.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/OpenKh.Engine/OpenKh.Engine.csproj
+++ b/OpenKh.Engine/OpenKh.Engine.csproj
@@ -1,8 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <Optimize>False</Optimize>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.Game/OpenKh.Game.csproj
+++ b/OpenKh.Game/OpenKh.Game.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <InformationalVersion>0.0.0.0-local</InformationalVersion>
     <ApplicationIcon />

--- a/OpenKh.Imaging/OpenKh.Imaging.csproj
+++ b/OpenKh.Imaging/OpenKh.Imaging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/OpenKh.Kh1/OpenKh.Kh1.csproj
+++ b/OpenKh.Kh1/OpenKh.Kh1.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/OpenKh.Kh2/OpenKh.Kh2.csproj
+++ b/OpenKh.Kh2/OpenKh.Kh2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
       <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/OpenKh.Kh2AnimEmu/OpenKh.Kh2AnimEmu.csproj
+++ b/OpenKh.Kh2AnimEmu/OpenKh.Kh2AnimEmu.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 

--- a/OpenKh.Patcher/OpenKh.Patcher.csproj
+++ b/OpenKh.Patcher/OpenKh.Patcher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenKh.Ps2/OpenKh.Ps2.csproj
+++ b/OpenKh.Ps2/OpenKh.Ps2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+      <TargetFrameworks>net6.0</TargetFrameworks>
       <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/OpenKh.Research.Kh2Anim/OpenKh.Research.Kh2Anim.csproj
+++ b/OpenKh.Research.Kh2Anim/OpenKh.Research.Kh2Anim.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/OpenKh.Tests.Commands/OpenKh.Tests.Commands.csproj
+++ b/OpenKh.Tests.Commands/OpenKh.Tests.Commands.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
 
     <IsPackable>false</IsPackable>

--- a/OpenKh.Tests.Engine/OpenKh.Tests.Engine.csproj
+++ b/OpenKh.Tests.Engine/OpenKh.Tests.Engine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/OpenKh.Tests/OpenKh.Tests.csproj
+++ b/OpenKh.Tests/OpenKh.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
 
     <IsPackable>false</IsPackable>

--- a/OpenKh.Tools.BarEditor/OpenKh.Tools.BarEditor.csproj
+++ b/OpenKh.Tools.BarEditor/OpenKh.Tools.BarEditor.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <AssemblyTitle>BAR editor</AssemblyTitle>

--- a/OpenKh.Tools.BbsEventTableEditor/OpenKh.Tools.BbsEventTableEditor.csproj
+++ b/OpenKh.Tools.BbsEventTableEditor/OpenKh.Tools.BbsEventTableEditor.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <AssemblyTitle>BBS Event table editor</AssemblyTitle>

--- a/OpenKh.Tools.BbsMapStudio/OpenKh.Tools.BbsMapStudio.csproj
+++ b/OpenKh.Tools.BbsMapStudio/OpenKh.Tools.BbsMapStudio.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net5.0-windows</TargetFramework>
+		<TargetFramework>net6.0-windows7.0</TargetFramework>
         <LangVersion>latest</LangVersion>
 		<AssemblyTitle>BBS Map Studio</AssemblyTitle>
 		<Product>BBS Map Studio - OpenKh</Product>

--- a/OpenKh.Tools.BepEditor/OpenKh.Tools.BepEditor.csproj
+++ b/OpenKh.Tools.BepEditor/OpenKh.Tools.BepEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/OpenKh.Tools.Common.CustomImGui/OpenKh.Tools.Common.CustomImGui.csproj
+++ b/OpenKh.Tools.Common.CustomImGui/OpenKh.Tools.Common.CustomImGui.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/OpenKh.Tools.Common.Wpf/OpenKh.Tools.Common.Wpf.csproj
+++ b/OpenKh.Tools.Common.Wpf/OpenKh.Tools.Common.Wpf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/OpenKh.Tools.Common/OpenKh.Tools.Common.csproj
+++ b/OpenKh.Tools.Common/OpenKh.Tools.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/OpenKh.Tools.CtdEditor/OpenKh.Tools.CtdEditor.csproj
+++ b/OpenKh.Tools.CtdEditor/OpenKh.Tools.CtdEditor.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <AssemblyTitle>CTD editor</AssemblyTitle>

--- a/OpenKh.Tools.DpdViewer/OpenKh.Tools.DpdViewer.csproj
+++ b/OpenKh.Tools.DpdViewer/OpenKh.Tools.DpdViewer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <AssemblyTitle>DPD viewer</AssemblyTitle>

--- a/OpenKh.Tools.EpdEditor/OpenKh.Tools.EpdEditor.csproj
+++ b/OpenKh.Tools.EpdEditor/OpenKh.Tools.EpdEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/OpenKh.Tools.IdxImg/OpenKh.Tools.IdxImg.csproj
+++ b/OpenKh.Tools.IdxImg/OpenKh.Tools.IdxImg.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/OpenKh.Tools.ImageViewer/OpenKh.Tools.ImageViewer.csproj
+++ b/OpenKh.Tools.ImageViewer/OpenKh.Tools.ImageViewer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <AssemblyTitle>Image viewer</AssemblyTitle>

--- a/OpenKh.Tools.ItbEditor/OpenKh.Tools.ItbEditor.csproj
+++ b/OpenKh.Tools.ItbEditor/OpenKh.Tools.ItbEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/OpenKh.Tools.ItcEditor/OpenKh.Tools.ItcEditor.csproj
+++ b/OpenKh.Tools.ItcEditor/OpenKh.Tools.ItcEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/OpenKh.Tools.Kh2BattleEditor/OpenKh.Tools.Kh2BattleEditor.csproj
+++ b/OpenKh.Tools.Kh2BattleEditor/OpenKh.Tools.Kh2BattleEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <AssemblyTitle>KH2 Battle editor</AssemblyTitle>

--- a/OpenKh.Tools.Kh2MapStudio/OpenKh.Tools.Kh2MapStudio.csproj
+++ b/OpenKh.Tools.Kh2MapStudio/OpenKh.Tools.Kh2MapStudio.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net5.0-windows</TargetFramework>
+		<TargetFramework>net6.0-windows</TargetFramework>
         <LangVersion>latest</LangVersion>
 		<AssemblyTitle>KH2 Map Studio</AssemblyTitle>
 		<Product>KH2 Map Studio - OpenKh</Product>

--- a/OpenKh.Tools.Kh2MdlxEditor/OpenKh.Tools.Kh2MdlxEditor.csproj
+++ b/OpenKh.Tools.Kh2MdlxEditor/OpenKh.Tools.Kh2MdlxEditor.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/OpenKh.Tools.Kh2MsetEditor/OpenKh.Tools.Kh2MsetEditor.csproj
+++ b/OpenKh.Tools.Kh2MsetEditor/OpenKh.Tools.Kh2MsetEditor.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/OpenKh.Tools.Kh2PlaceEditor/OpenKh.Tools.Kh2PlaceEditor.csproj
+++ b/OpenKh.Tools.Kh2PlaceEditor/OpenKh.Tools.Kh2PlaceEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <AssemblyTitle>KH2 Place editor</AssemblyTitle>

--- a/OpenKh.Tools.Kh2SystemEditor/OpenKh.Tools.Kh2SystemEditor.csproj
+++ b/OpenKh.Tools.Kh2SystemEditor/OpenKh.Tools.Kh2SystemEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <AssemblyTitle>KH2 System editor</AssemblyTitle>

--- a/OpenKh.Tools.Kh2TextEditor/OpenKh.Tools.Kh2TextEditor.csproj
+++ b/OpenKh.Tools.Kh2TextEditor/OpenKh.Tools.Kh2TextEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <AssemblyTitle>KH2 Text editor</AssemblyTitle>

--- a/OpenKh.Tools.LayoutEditor/OpenKh.Tools.LayoutEditor.csproj
+++ b/OpenKh.Tools.LayoutEditor/OpenKh.Tools.LayoutEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>Layout editor</AssemblyTitle>
     <Product>Layout editor - OpenKh</Product>

--- a/OpenKh.Tools.MissionEditor/OpenKh.Tools.MissionEditor.csproj
+++ b/OpenKh.Tools.MissionEditor/OpenKh.Tools.MissionEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/OpenKh.Tools.ModsManager/OpenKh.Tools.ModsManager.csproj
+++ b/OpenKh.Tools.ModsManager/OpenKh.Tools.ModsManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <AssemblyTitle>Mods Manager</AssemblyTitle>
     <Product>Mods Manager - OpenKH</Product>

--- a/OpenKh.Tools.ObjentryEditor/OpenKh.Tools.ObjentryEditor.csproj
+++ b/OpenKh.Tools.ObjentryEditor/OpenKh.Tools.ObjentryEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
     <AssemblyTitle>KH2 Objentry editor</AssemblyTitle>

--- a/OpenKh.Tools.OloEditor/OpenKh.Tools.OloEditor.csproj
+++ b/OpenKh.Tools.OloEditor/OpenKh.Tools.OloEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/OpenKh.Tools.PAtkEditor/OpenKh.Tools.PAtkEditor.csproj
+++ b/OpenKh.Tools.PAtkEditor/OpenKh.Tools.PAtkEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/Playground/Playground.csproj
+++ b/Playground/Playground.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>ConsoleApp1</AssemblyTitle>
     <Product>ConsoleApp1</Product>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ New builds of OpenKH are automatically generated every time one of the contribut
 
 All the builds from `master` and from pull requestes are generated from [Azure Pipelines](https://dev.azure.com/xeeynamo/OpenKH/_build).
 
-OpenKH tools require the instllation of the [.NET 5.0 Runtime](https://dotnet.microsoft.com/download/dotnet/5.0). All the UI tools are designed to work on Windows, while command line tools will work on any operating system.
+OpenKH tools require the instllation of the [.NET 6.0 Runtime](https://dotnet.microsoft.com/download/dotnet/6.0). All the UI tools are designed to work on Windows, while command line tools will work on any operating system.
 Note: All CLI and GUI programs **should** be cross-platform, though extensive testing primarily happens on Windows systems.
 
 <p align="center">
@@ -37,7 +37,7 @@ From a community perspective, OpenKH will provide the best form of documentation
 
 ## Build from source code
 
-The minimum requirement is [.NET 5 SDK](https://dotnet.microsoft.com/download/dotnet/5.0). Once the repository is downloaded, `build.ps1` or `build.sh` needs be executed based from the operating system in use. That is all.
+The minimum requirement is [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0). Once the repository is downloaded, `build.ps1` or `build.sh` needs be executed based from the operating system in use. That is all.
 
 ## Additional info
 

--- a/build.ps1
+++ b/build.ps1
@@ -73,7 +73,7 @@ Get-CSProjects "OpenKh.Game*" | ForEach-Object {
 }
 
 # Publish solution
-dotnet publish $solution --configuration $configuration --verbosity $verbosity --framework net5.0 --output $output /p:DebugType=None /p:DebugSymbols=false
+dotnet publish $solution --configuration $configuration --verbosity $verbosity --framework net6.0 --output $output /p:DebugType=None /p:DebugSymbols=false
 
 # Remove the temporary solution after the solution is published
 Remove-Item $solution -ErrorAction Ignore


### PR DESCRIPTION
Replaces #509 
Target 5.0 with 6.0 sdk
![afbeelding](https://user-images.githubusercontent.com/13855042/163714137-f7f3f2c7-7353-473b-a7a6-735fd3fedad5.png)
Target 6.0 with 6.0 sdk
![afbeelding](https://user-images.githubusercontent.com/13855042/163714179-092abbec-1d7e-4c24-82fa-15d14716688a.png)

There were some people in some regions where VS2022 doesn't run well on older hardware and want to still use VS2019 instead. However this isn't possible with the release version of the 6.0 SDK. However you can use the preview 4 build of the SDK with VS2019 as a stop gap solution. I don't know How long that would work if some new features are being used.
