### PR TITLE
Fix PNG decompression

### DIFF
--- a/OpenKh.Imaging/PngImage.cs
+++ b/OpenKh.Imaging/PngImage.cs
@@ -273,7 +273,7 @@ namespace OpenKh.Imaging
             }
             else
             {
-                throw new NotSupportedException();
+                throw new NotSupportedException($"PNG filter {filter} not supported");
             }
         }
 

--- a/OpenKh.Imaging/PngImage.cs
+++ b/OpenKh.Imaging/PngImage.cs
@@ -134,12 +134,12 @@ namespace OpenKh.Imaging
 
             fullData.Position = 2;
 
-            var deflater = new DeflateStream(fullData, CompressionMode.Decompress);
-
-            Size = new Size(ihdr.Width, ihdr.Height);
+            using var deflater = new DeflateStream(fullData, CompressionMode.Decompress);
+            using var deflated = new BufferedStream(deflater);
 
             var bits = ihdr.Bits;
             var colorType = (ColorType)ihdr.ColorType;
+            Size = new Size(ihdr.Width, ihdr.Height);
 
             if (bits == 4 && colorType == ColorType.Indexed)
             {
@@ -148,8 +148,8 @@ namespace OpenKh.Imaging
                 _data = new byte[stride * Size.Height];
                 for (int y = 0; y < Size.Height; y++)
                 {
-                    var filter = deflater.ReadByte();
-                    deflater.Read(_data, y * stride, stride);
+                    var filter = deflated.ReadByte();
+                    deflated.Read(_data, y * stride, stride);
                     ApplyFilter(_data, y * stride, 1, stride, filter);
                 }
                 _clut = PrepareClut(PLTE, tRNS, 16);
@@ -161,8 +161,8 @@ namespace OpenKh.Imaging
                 _data = new byte[stride * Size.Height];
                 for (int y = 0; y < Size.Height; y++)
                 {
-                    var filter = deflater.ReadByte();
-                    deflater.Read(_data, y * stride, stride);
+                    var filter = deflated.ReadByte();
+                    deflated.Read(_data, y * stride, stride);
                     ApplyFilter(_data, y * stride, 1, stride, filter);
                 }
                 _clut = PrepareClut(PLTE, tRNS, 256);
@@ -174,8 +174,8 @@ namespace OpenKh.Imaging
                 _data = new byte[stride * Size.Height];
                 for (int y = 0; y < Size.Height; y++)
                 {
-                    var filter = deflater.ReadByte();
-                    deflater.Read(_data, y * stride, stride);
+                    var filter = deflated.ReadByte();
+                    deflated.Read(_data, y * stride, stride);
                     ApplyFilter(_data, y * stride, 3, stride, filter);
                 }
             }
@@ -186,8 +186,8 @@ namespace OpenKh.Imaging
                 _data = new byte[stride * Size.Height];
                 for (int y = 0; y < Size.Height; y++)
                 {
-                    var filter = deflater.ReadByte();
-                    deflater.Read(_data, y * stride, stride);
+                    var filter = deflated.ReadByte();
+                    deflated.Read(_data, y * stride, stride);
                     ApplyFilter(_data, y * stride, 4, stride, filter);
                 }
 

--- a/OpenKh.Patcher/PatcherProcessor.cs
+++ b/OpenKh.Patcher/PatcherProcessor.cs
@@ -200,8 +200,15 @@ namespace OpenKh.Patcher
             using var srcStream = File.OpenRead(srcFile);
             if (PngImage.IsValid(srcStream))
             {
-                var png = PngImage.Read(srcStream);
-                return Imgd.Create(png.Size, png.PixelFormat, png.GetData(), png.GetClut(), source.IsSwizzled);
+                try
+                {
+                    var png = PngImage.Read(srcStream);
+                    return Imgd.Create(png.Size, png.PixelFormat, png.GetData(), png.GetClut(), source.IsSwizzled);
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception($"Unable to decode the PNG '{source.Name}': {ex.Message}");
+                }
             }
             else if (Imgd.IsValid(srcStream))
                 return Imgd.Read(srcStream);


### PR DESCRIPTION
The new .NET 6 #598 has a breaking change on how [GZip decompression is handled](https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams). We are using the library `DeflateStream` which is mainly used by `PngImage`. This bug affects the following products:

* PmoConverter
* PmpConverter
* Mods Manager
* Image Viewer

Essentially it is now impossible to just read byte by byte from `DeflateStream` so now we need a buffer to unload the decompressed data before reading it from a stream. Luckily `BufferedStream` does the trick and the fix is quite straightforward. I also took the opportunity to improve the error logging if a PNG acts weird.