### PR TITLE
Fix OpenKH.Engine crash

### DIFF
--- a/OpenKh.Engine/Motion/Kh2MotionEngine.cs
+++ b/OpenKh.Engine/Motion/Kh2MotionEngine.cs
@@ -84,8 +84,8 @@ namespace OpenKh.Engine.Motion
                 model.ApplyMotion(model.InitialPose);
             else if (CurrentMotion.IsRaw)
                 ApplyRawMotion(model, CurrentMotion.Raw, time);
-            //else
-                //ApplyInterpolatedMotion(model, CurrentMotion.Interpolated, time);
+            else
+                ApplyInterpolatedMotion(model, CurrentMotion.Interpolated, time);
         }
 
         private void ApplyRawMotion(IModelMotion model, Kh2.Motion.RawMotion_OLD motion, float time)

--- a/OpenKh.Game/Config.cs
+++ b/OpenKh.Game/Config.cs
@@ -124,8 +124,8 @@ namespace OpenKh.Game
                 };
 
                 while (!_tokenSource.Token.IsCancellationRequested)
-                    Thread.Sleep(1000);
-
+                    Thread.Sleep(10);
+                _tokenSource.Dispose();
             }, _tokenSource.Token);
         }
 
@@ -137,7 +137,7 @@ namespace OpenKh.Game
 
         public static void Close()
         {
-            _tokenSource?.Dispose();
+            _tokenSource.Cancel();
         }
     }
 }


### PR DESCRIPTION
When closing the engine there was an occasional crash. This is now fixed. I also re-enabled the entity animation as it was commented out for some obscure reason.