### PR TITLE
Remove COM reference in msetEditor to fix dotnet build

### DIFF
--- a/OpenKh.Tools.Kh2MsetEditor/OpenKh.Tools.Kh2MsetEditor.csproj
+++ b/OpenKh.Tools.Kh2MsetEditor/OpenKh.Tools.Kh2MsetEditor.csproj
@@ -8,15 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <COMReference Include="{215d64d2-031c-33c7-96e3-61794cd1ee61}">
-      <WrapperTool>tlbimp</WrapperTool>
-      <VersionMinor>0</VersionMinor>
-      <VersionMajor>2</VersionMajor>
-      <Guid>215d64d2-031c-33c7-96e3-61794cd1ee61</Guid>
-    </COMReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\OpenKh.Command.Bar\OpenKh.Command.Bar.csproj" />
     <ProjectReference Include="..\OpenKh.Tools.ImageViewer\OpenKh.Tools.ImageViewer.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Removes the COM (Not Chain Of Memories) reference in KH2.msetEditor to fix the dotnet build command