### PR TITLE
BFMM Functionality in Mod Manager.

### DIFF
--- a/OpenKh.Egs/EgsTools.cs
+++ b/OpenKh.Egs/EgsTools.cs
@@ -18,8 +18,6 @@ namespace OpenKh.Egs
         private const string ORIGINAL_FILES_FOLDER_NAME = "original";
         private const string REMASTERED_FILES_FOLDER_NAME = "remastered";
 
-        delegate void ActionRef<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, ref T4 item4, T5 item5);
-
         #region MD5 names
 
         private static readonly IEnumerable<string> KH2Names = IdxName.Names

--- a/OpenKh.Egs/EgsTools.cs
+++ b/OpenKh.Egs/EgsTools.cs
@@ -18,6 +18,8 @@ namespace OpenKh.Egs
         private const string ORIGINAL_FILES_FOLDER_NAME = "original";
         private const string REMASTERED_FILES_FOLDER_NAME = "remastered";
 
+        delegate void ActionRef<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, ref T4 item4, T5 item5);
+
         #region MD5 names
 
         private static readonly IEnumerable<string> KH2Names = IdxName.Names
@@ -51,7 +53,7 @@ namespace OpenKh.Egs
                     "ICON/ICON0_EN.png",
             });
 
-        private static readonly Dictionary<string, string> Names = KH2Names
+        public static readonly Dictionary<string, string> Names = KH2Names
             .Concat(Idx1Name.Names)
             .Concat(EgsHdAsset.DddNames)
             .Concat(EgsHdAsset.BbsNames)
@@ -133,7 +135,7 @@ namespace OpenKh.Egs
             }
         }
 
-        private static string GetHDAssetFolder(string assetFile)
+        public static string GetHDAssetFolder(string assetFile)
         {
             var parentFolder = Directory.GetParent(assetFile).FullName;
             var assetFolderName = Path.Combine(parentFolder, $"{Path.GetFileName(assetFile)}");
@@ -141,7 +143,7 @@ namespace OpenKh.Egs
             return assetFolderName;
         }
 
-        private static void CreateDirectoryForFile(string fileName)
+        public static void CreateDirectoryForFile(string fileName)
         {
             var directoryName = Path.GetDirectoryName(fileName);
             if (!Directory.Exists(directoryName))
@@ -214,7 +216,7 @@ namespace OpenKh.Egs
             }
         }
 
-        private static Hed.Entry AddFile(string inputFolder, string filename, FileStream hedStream, FileStream pkgStream, bool shouldCompressData = false, bool shouldEncryptData = false)
+        public static Hed.Entry AddFile(string inputFolder, string filename, FileStream hedStream, FileStream pkgStream, bool shouldCompressData = false, bool shouldEncryptData = false)
         {
             var completeFilePath = Path.Combine(inputFolder, ORIGINAL_FILES_FOLDER_NAME, filename);
             var completeRawFilePath = Path.Combine(inputFolder, RAW_FILES_FOLDER_NAME, filename);
@@ -318,7 +320,7 @@ namespace OpenKh.Egs
             return hedHeader;
         }
 
-        private static Hed.Entry ReplaceFile(string inputFolder, string filename, FileStream hedStream, FileStream pkgStream, EgsHdAsset asset, Hed.Entry originalHedHeader = null)
+        public static Hed.Entry ReplaceFile(string inputFolder, string filename, FileStream hedStream, FileStream pkgStream, EgsHdAsset asset, Hed.Entry originalHedHeader = null)
         {
             var completeFilePath = Path.Combine(inputFolder, ORIGINAL_FILES_FOLDER_NAME, filename);
             var completeRawFilePath = Path.Combine(inputFolder, RAW_FILES_FOLDER_NAME, filename);

--- a/OpenKh.Patcher/Metadata.cs
+++ b/OpenKh.Patcher/Metadata.cs
@@ -42,6 +42,8 @@ namespace OpenKh.Patcher
     {
         public string Name { get; set; }
         public string Method { get; set; }
+        public string Platform { get; set; }
+        public string Package { get; set; }
         public List<Multi> Multi { get; set; }
         public List<AssetFile> Source { get; set; }
 

--- a/OpenKh.Patcher/Metadata.cs
+++ b/OpenKh.Patcher/Metadata.cs
@@ -36,6 +36,8 @@ namespace OpenKh.Patcher
             deserializer.Deserialize<Metadata>(new StreamReader(stream));
         public void Write(Stream stream) =>
             serializer.Serialize(new StreamWriter(stream), this);
+        public override string ToString() =>
+        serializer.Serialize(this);
     }
 
     public class AssetFile

--- a/OpenKh.Tools.ModsManager/OpenKh.Tools.ModsManager.csproj
+++ b/OpenKh.Tools.ModsManager/OpenKh.Tools.ModsManager.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OpenKh.Common\OpenKh.Common.csproj" />
+    <ProjectReference Include="..\OpenKh.Egs\OpenKh.Egs.csproj" />
     <ProjectReference Include="..\OpenKh.Kh2\OpenKh.Kh2.csproj" />
     <ProjectReference Include="..\OpenKh.Patcher\OpenKh.Patcher.csproj" />
     <ProjectReference Include="..\OpenKh.Tools.Common.WPF\OpenKh.Tools.Common.Wpf.csproj" />

--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -313,6 +313,7 @@ namespace OpenKh.Tools.ModsManager.Services
                     Log.Warn("Unable to fully clean the mod directory:\n{0}", ex.Message);
                 }
             }
+
             Directory.CreateDirectory(ConfigurationService.GameModPath);
 
             var patcherProcessor = new PatcherProcessor();

--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -138,11 +138,14 @@ namespace OpenKh.Tools.ModsManager.Services
                 var _splitStr = _str.Split(_strSplitter);
                 var _package = _splitStr[0];
 
-                if (_str.Contains("original"))
-                    _str = String.Join("\\", _splitStr.Skip(2));
+                if (isModPatch)
+                {
+                    if (_str.Contains("original"))
+                        _str = String.Join("\\", _splitStr.Skip(2));
 
-                else
-                    _str = String.Join("\\", _splitStr.Skip(1));
+                    else
+                        _str = String.Join("\\", _splitStr.Skip(1));
+                }
 
                 progressOutput?.Invoke($"Extracting '{_str}'...");
                 progressNumber?.Invoke((float)entryExtractCount / entryCount);

--- a/OpenKh.Tools.ModsManager/Services/ModsService.cs
+++ b/OpenKh.Tools.ModsManager/Services/ModsService.cs
@@ -18,6 +18,26 @@ namespace OpenKh.Tools.ModsManager.Services
         private const string ModMetadata = "mod.yml";
         private const string DefaultGitBranch = "main";
 
+        private static string[] _gameList = new string[]
+        {
+            "OpenKH",
+            "PCSX2-EX",
+            "PC"
+        };
+
+        private static string[] _langList = new string[]
+        {
+            "Default",
+            "Japanese",
+            "English [US]",
+            "English [UK]",
+            "Italian",
+            "Spanish",
+            "German",
+            "French",
+            "Final Mix"
+        };
+
         public static IEnumerable<string> Mods
         {
             get
@@ -219,7 +239,7 @@ namespace OpenKh.Tools.ModsManager.Services
             Action<float> progressNumber = null) =>
             RepositoryService.FetchAndResetUponOrigin(GetModPath(modName), progressOutput, progressNumber);
 
-        public static Task<bool> RunPacherAsync() => Task.Run(() => Handle(() =>
+        public static Task<bool> RunPacherAsync(bool fastMode) => Task.Run(() => Handle(() =>
         {
             if (Directory.Exists(ConfigurationService.GameModPath))
             {
@@ -236,16 +256,19 @@ namespace OpenKh.Tools.ModsManager.Services
 
             var patcherProcessor = new PatcherProcessor();
             var modsList = GetMods(EnabledMods).ToList();
+
             for (var i = modsList.Count - 1; i >= 0; i--)
             {
                 var mod = modsList[i];
-                Log.Info($"Patching using {mod.Name} from {mod.Path}");
+                Log.Info($"Building {mod.Name} for {_gameList[ConfigurationService.GameEdition]} - {_langList[ConfigurationService.RegionId]}");
 
                 patcherProcessor.Patch(
                     ConfigurationService.GameDataLocation,
                     ConfigurationService.GameModPath,
                     mod.Metadata,
-                    mod.Path);
+                    mod.Path,
+                    ConfigurationService.GameEdition,
+                    fastMode);
             }
 
             return true;

--- a/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModsManager/ViewModels/MainViewModel.cs
@@ -4,6 +4,7 @@ using OpenKh.Tools.ModsManager.Models;
 using OpenKh.Tools.ModsManager.Services;
 using OpenKh.Tools.ModsManager.Views;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
@@ -35,6 +36,10 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         private Process _runningProcess;
         private bool _isBuilding;
 
+        private const string RAW_FILES_FOLDER_NAME = "raw";
+        private const string ORIGINAL_FILES_FOLDER_NAME = "original";
+        private const string REMASTERED_FILES_FOLDER_NAME = "remastered";
+
         public string Title => ApplicationName;
         public string CurrentVersion => ApplicationVersion;
         public ObservableCollection<ModViewModel> ModsList { get; set; }
@@ -45,6 +50,8 @@ namespace OpenKh.Tools.ModsManager.ViewModels
         public RelayCommand MoveUp { get; set; }
         public RelayCommand MoveDown { get; set; }
         public RelayCommand BuildCommand { get; set; }
+        public RelayCommand PatchCommand { get; set; }
+        public RelayCommand RestoreCommand { get; set; }
         public RelayCommand RunCommand { get; set; }
         public RelayCommand BuildAndRunCommand { get; set; }
         public RelayCommand StopRunningInstanceCommand { get; set; }
@@ -183,20 +190,36 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             BuildCommand = new RelayCommand(async _ =>
             {
                 ResetLogWindow();
-                await BuildPatches();
+                await BuildPatches(false);
                 CloseAllWindows();
             }, _ => !IsBuilding);
+
+            PatchCommand = new RelayCommand(async (fastMode) =>
+            {
+                ResetLogWindow();
+                await BuildPatches(Convert.ToBoolean(fastMode));
+                await PatchGame(Convert.ToBoolean(fastMode));
+                CloseAllWindows();
+            }, _ => !IsBuilding);
+
             RunCommand = new RelayCommand(async _ =>
             {
                 CloseRunningProcess();
                 ResetLogWindow();
                 await RunGame();
             });
+
+            RestoreCommand = new RelayCommand(async _ =>
+            {
+                ResetLogWindow();
+                await RestoreGame();
+                CloseAllWindows();
+            });
             BuildAndRunCommand = new RelayCommand(async _ =>
             {
                 CloseRunningProcess();
                 ResetLogWindow();
-                if (await BuildPatches())
+                if (await BuildPatches(false))
                     await RunGame();
             }, _ => !IsBuilding);
             StopRunningInstanceCommand = new RelayCommand(_ =>
@@ -268,10 +291,10 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             _debuggingWindow.ClearLogs();
         }
 
-        private async Task<bool> BuildPatches()
+        private async Task<bool> BuildPatches(bool fastMode)
         {
             IsBuilding = true;
-            var result = await ModsService.RunPacherAsync();
+            var result = await ModsService.RunPacherAsync(fastMode);
             IsBuilding = false;
 
             return result;
@@ -399,6 +422,151 @@ namespace OpenKh.Tools.ModsManager.ViewModels
             ModsList.Insert(--selectedIndex, item);
             SelectedValue = ModsList[selectedIndex];
             ModEnableStateChanged();
+        }
+
+        private async Task PatchGame(bool fastMode)
+        {
+            await Task.Run(() =>
+            {
+                if (ConfigurationService.GameEdition == 2)
+                {
+                    foreach (var directory in Directory.GetDirectories(ConfigurationService.GameModPath))
+                    {
+                        var patchFiles = new List<string>();
+                        var _dirPart = new DirectoryInfo(directory).Name;
+
+                        var _orgPath = Path.Combine(directory, ORIGINAL_FILES_FOLDER_NAME);
+                        var _rawPath = Path.Combine(directory, RAW_FILES_FOLDER_NAME);
+
+                        if (Directory.Exists(_orgPath))
+                            patchFiles = OpenKh.Egs.Helpers.GetAllFiles(_orgPath).ToList();
+
+                        if (Directory.Exists(_rawPath))
+                            patchFiles.AddRange(OpenKh.Egs.Helpers.GetAllFiles(_rawPath).ToList());
+
+                        var _pkgSoft = fastMode ? "kh2_first" : _dirPart;
+                        var _pkgName = Path.GetDirectoryName(ConfigurationService.PcReleaseLocation) + "/Image/en/" + _pkgSoft + ".pkg";
+
+                        var _backupDir = Path.GetDirectoryName(ConfigurationService.PcReleaseLocation) + "/BackupImage";
+
+                        if (!Directory.Exists(Path.GetDirectoryName(ConfigurationService.PcReleaseLocation) + "/BackupImage"))
+                            Directory.CreateDirectory(_backupDir);
+
+                        var filenames = new List<string>();
+                        var outputDir = "patchedpkgs";
+                        var hedFile = Path.ChangeExtension(_pkgName, "hed");
+
+                        if (!File.Exists(_backupDir + "/" + _pkgSoft + ".pkg"))
+                        {
+                            Log.Info($"Backing Up Package File {_pkgSoft}");
+
+                            File.Copy(_pkgName, _backupDir + "/" + _pkgSoft + ".pkg");
+                            File.Copy(hedFile, _backupDir + "/" + _pkgSoft + ".hed");
+                        }
+
+                        else
+                        {
+                            Log.Info($"Restoring Package File {_pkgSoft}");
+
+                            File.Delete(hedFile);
+                            File.Delete(_pkgName);
+
+                            File.Copy(_backupDir + "/" + _pkgSoft + ".pkg", _pkgName);
+                            File.Copy(_backupDir + "/" + _pkgSoft + ".hed", hedFile);
+                        }
+
+                        using var hedStream = File.OpenRead(hedFile);
+                        using var pkgStream = File.OpenRead(_pkgName);
+                        var hedHeaders = OpenKh.Egs.Hed.Read(hedStream).ToList();
+
+                        if (!Directory.Exists(outputDir))
+                            Directory.CreateDirectory(outputDir);
+
+                        using var patchedHedStream = File.Create(Path.Combine(outputDir, Path.GetFileName(hedFile)));
+                        using var patchedPkgStream = File.Create(Path.Combine(outputDir, Path.GetFileName(_pkgName)));
+
+                        foreach (var hedHeader in hedHeaders)
+                        {
+                            var hash = OpenKh.Egs.Helpers.ToString(hedHeader.MD5);
+
+                            // We don't know this filename, we ignore it
+                            if (!OpenKh.Egs.EgsTools.Names.TryGetValue(hash, out var filename))
+                                continue;
+
+                            var asset = new OpenKh.Egs.EgsHdAsset(pkgStream.SetPosition(hedHeader.Offset));
+
+                            if (patchFiles.Contains(filename))
+                            {
+                                patchFiles.Remove(filename);
+
+                                filenames.Add(filename);
+
+                                if (hedHeader.DataLength > 0)
+                                {
+                                    OpenKh.Egs.EgsTools.ReplaceFile(directory, filename, patchedHedStream, patchedPkgStream, asset, hedHeader);
+                                    Log.Info($"Replacing File {filename} in {_pkgSoft}");
+                                }
+                            }
+
+                            else
+                            {
+                                OpenKh.Egs.EgsTools.ReplaceFile(directory, filename, patchedHedStream, patchedPkgStream, asset, hedHeader);
+                                Log.Info($"Skipped File {filename} in {_pkgSoft}");
+                            }
+                        }
+
+                        // Add all files that are not in the original HED file and inject them in the PKG stream too
+                        foreach (var filename in patchFiles)
+                        {
+                            OpenKh.Egs.EgsTools.AddFile(directory, filename, patchedHedStream, patchedPkgStream);
+                            Log.Info($"Adding File {filename} to {_pkgSoft}");
+                        }
+
+                        hedStream.Close();
+                        pkgStream.Close();
+
+                        patchedHedStream.Close();
+                        patchedPkgStream.Close();
+
+                        File.Delete(hedFile);
+                        File.Delete(_pkgName);
+
+                        File.Move(Path.Combine(outputDir, Path.GetFileName(hedFile)), hedFile);
+                        File.Move(Path.Combine(outputDir, Path.GetFileName(_pkgName)), _pkgName);
+                    }
+                }
+            });
+        }
+
+        private async Task RestoreGame()
+        {
+            await Task.Run(() =>
+            {
+                if (ConfigurationService.GameEdition == 2)
+                {
+                    if (!Directory.Exists(Path.GetDirectoryName(ConfigurationService.PcReleaseLocation) + "/BackupImage"))
+                    {
+                        Log.Warn("backup folder cannot be found! Cannot restore the game.");
+                    }
+
+                    else
+                    {
+                        foreach (var file in Directory.GetFiles(Path.GetDirectoryName(ConfigurationService.PcReleaseLocation) + "/BackupImage").Where(x => x.Contains(".pkg")))
+                        {
+                            Log.Info($"Restoring Package File {file.Replace(".pkg", "")}");
+
+                            var _fileBare = Path.GetFileName(file);
+                            var _trueName = Path.GetDirectoryName(ConfigurationService.PcReleaseLocation) + "/Image/en/" + _fileBare;
+
+                            File.Delete(Path.ChangeExtension(_trueName, "hed"));
+                            File.Delete(_trueName);
+
+                            File.Copy(file, _trueName);
+                            File.Copy(Path.ChangeExtension(file, "hed"), Path.ChangeExtension(_trueName, "hed"));
+                        }
+                    }
+                }
+            });
         }
 
         private bool CanSelectedModMoveDown() =>

--- a/OpenKh.Tools.ModsManager/Views/InstallModView.xaml
+++ b/OpenKh.Tools.ModsManager/Views/InstallModView.xaml
@@ -30,8 +30,8 @@
                 <TextBox Name="txtSourceModUrl" Background="Transparent" Text="{Binding RepositoryName, UpdateSourceTrigger=PropertyChanged}" KeyUp="txtSourceModUrl_KeyUp" />
             </Grid>
 
-            <TextBlock Margin="0 0 0 3">Or install it from a ZIP archive</TextBlock>
-            <Button Margin="0 0 0 5" Click="InstallZip_Click">Select and install ZIP</Button>
+            <TextBlock Margin="0 0 0 3">Or install it from a Mod Archive</TextBlock>
+            <Button Margin="0 0 0 5" Click="InstallZip_Click">Select and install Mod Archive</Button>
         </StackPanel>
 
         <Grid Grid.Row="2">

--- a/OpenKh.Tools.ModsManager/Views/InstallModView.xaml.cs
+++ b/OpenKh.Tools.ModsManager/Views/InstallModView.xaml.cs
@@ -13,7 +13,8 @@ namespace OpenKh.Tools.ModsManager.Views
     {
         private static readonly IEnumerable<FileDialogFilter> _zipFilter = FileDialogFilterComposer
             .Compose()
-            .AddExtensions("OpenKH mod as ZIP file", "zip");
+            .AddExtensions("OpenKH ZIP Mod", "zip")
+            .AddExtensions("KH2PCPATCH Mod", "kh2pcpatch");
 
         public RelayCommand CloseCommand { get; }
         public string RepositoryName { get; set; }

--- a/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/MainWindow.xaml
@@ -64,10 +64,15 @@
                 <Separator/>
                 <MenuItem Header="E_xit" Command="{Binding ExitCommand}" InputGestureText="Alt+F4"/>
             </MenuItem>
-            <MenuItem Header="_Run">
-                <MenuItem Header="Build and _run" Command="{Binding BuildAndRunCommand}" InputGestureText="F5"/>
-                <MenuItem Header="Build only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
-                <MenuItem Header="Run only" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
+            <MenuItem Header="Game">
+                <MenuItem Header="Build...">
+                    <MenuItem Header="Build Only" Command="{Binding BuildCommand}" InputGestureText="Ctrl+B"/>
+                    <MenuItem Header="Build and Patch [PC]" Command="{Binding PatchCommand}" CommandParameter="false" InputGestureText="Ctrl+P"/>
+                    <MenuItem Header="Build and Patch [Fast/PC]" Command="{Binding PatchCommand}" CommandParameter="true" InputGestureText="Ctrl+P+F"/>
+                    <MenuItem Header="Build and Run [OpenKH/PCSX2]" Command="{Binding BuildAndRunCommand}" InputGestureText="F5"/>
+                </MenuItem>
+                <MenuItem Header="Run [OpenKH/PCSX2]" Command="{Binding RunCommand}" InputGestureText="Ctrl+F5"/>
+                <MenuItem Header="Restore [PC]" Command="{Binding RestoreCommand}" InputGestureText="Ctrl+R"/>
                 <MenuItem Header="Stop" Command="{Binding StopRunningInstanceCommand}" InputGestureText="Shift+F5"/>
             </MenuItem>
             <MenuItem Header="_Settings">

--- a/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
+++ b/OpenKh.Tools.ModsManager/Views/SetupWizardWindow.xaml
@@ -38,7 +38,7 @@
                 <ComboBox Margin="0 0 0 6" SelectedIndex="{Binding GameEdition}">
                     <ComboBoxItem>OpenKH Game Engine</ComboBoxItem>
                     <ComboBoxItem>PlayStation 2 using PCSX2 emulator</ComboBoxItem>
-                    <ComboBoxItem Visibility="Hidden">PC release via Epic Game store</ComboBoxItem>
+                    <ComboBoxItem>PC Release via Epic Game Store</ComboBoxItem>
                 </ComboBox>
                 <StackPanel Visibility="{Binding OpenKhGameEngineConfigVisibility}">
                     <TextBlock Margin="0 0 0 3">Please select the location of OpenKH Game Engine</TextBlock>
@@ -89,14 +89,14 @@
             PageType="Interior"
             Title="Configure the game you want to mod"
             Description="Do not worry, you can change this option later"
-            CanSelectNextPage="{Binding IsGameRecognized}"
             NextPage="{Binding ElementName=PageGameData}">
             <StackPanel>
                 <TextBlock>Supported games:</TextBlock>
                 <StackPanel Margin="10 3 0 10">
                     <TextBlock>Kingdom Hearts II (JP, US, EU, Final Mix)</TextBlock>
                 </StackPanel>
-                <TextBlock Margin="0 0 0 3">Please select the location of the PlayStation 2 ISO image</TextBlock>
+                <TextBlock Margin="0 0 0 3">Please select the location of the PlayStation 2 ISO Image.</TextBlock>
+                <TextBlock Margin="0 0 0 3">If working with the PC release, leave this page blank.</TextBlock>
                 <Grid Margin="0 0 0 3">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
@@ -120,8 +120,8 @@
         <xctk:WizardPage
             x:Name="PageGameData"
             PageType="Interior"
-            Title="Set game data"
-            Description="It might be necessary to extract game's data"
+            Title="Set Game Data Location"
+            Description="It might be necessary to extract game's data."
             CanSelectNextPage="{Binding IsGameDataFound}"
             CanSelectPreviousPage="{Binding IsNotExtracting}"
             CanCancel="{Binding IsNotExtracting}"


### PR DESCRIPTION
Build_From_MM was a Python program used which allowed for Mod Manager mods to be used in the PC ports.
This PR basically takes in everything it can do and implements it to Mod Manager itself so that **we don't have to fiddle around.**

What it does:
- Allowing the Mod Manager to be set up for the PC ports.
- Building for OpenKH/PS2/PC specifically (Depending on what was declared in the wizard.)
- Extraction, Patching [Regular and "Fast"], and Backup of the EGS games.
- Restoration of the backups made with MM.

What it adds to "mod.yml":
- The "platform" tag to specifically state if a file is for a specific platform [pc, ps2, both] (Assumed "both" if not present.)
- The "package" tag to use with PC only. Tells a file where exactly to be patched to [kh2_* first, second, third, fourth, fifth, sixth] (Ignored on non-PC platforms. Assumed "kh2_first" if not present.)

From the tests made, it works surprisingly well. And it is able to patch the game ridiculously fast and is compliant with everything OpenKH tries to accomplish. Some of the "OpenKh.Egs" functions were implemented to MM separately as trying to use them would mean there would be no indication as to what was done.

I know the code is kinda messy, and there are still some things I have to do, I have to tidy up the code, add kh2pcpatch support, make sure shit works with everything etc. But this update was heavily requested by the majority of the modding community, and I had to deliver. 